### PR TITLE
feat: add env/envFile support per launch preset

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -888,6 +888,25 @@ private fun describeConfig(
   }
 }
 
+private fun parseEnvFile(path: Path): Map<String, String> {
+  if (!Files.exists(path)) {
+    logger.warning("envFile not found: $path")
+    return emptyMap()
+  }
+  val result = mutableMapOf<String, String>()
+  Files.readAllLines(path, StandardCharsets.UTF_8).forEachIndexed { lineNum, line ->
+    val trimmed = line.trim()
+    if (trimmed.isEmpty() || trimmed.startsWith("#")) return@forEachIndexed
+    val eq = trimmed.indexOf('=')
+    if (eq <= 0) {
+      logger.warning("envFile $path line ${lineNum + 1}: expected KEY=VALUE, skipping: $trimmed")
+      return@forEachIndexed
+    }
+    result[trimmed.substring(0, eq).trim()] = trimmed.substring(eq + 1)
+  }
+  return result
+}
+
 private fun selectLaunchConfig(
   context: LaunchConfigContext,
   launchName: String?,
@@ -917,6 +936,11 @@ private fun selectLaunchConfig(
     logger.severe("Launch '$launchName' not found in ${context.file}. Available launches: $available")
     return null
   }
+  val fileEnv: Map<String, String> = selected.envFile
+    ?.let { context.baseDir.resolve(it) }
+    ?.let { parseEnvFile(it) }
+    ?: emptyMap()
+  val env = fileEnv + selected.env
   val runtime = context.runtime.copy(
     product = selected.product,
     application = selected.application,
@@ -925,7 +949,8 @@ private fun selectLaunchConfig(
     programArgs = selected.programArgs,
     dataDir = selected.dataDir,
     configDir = selected.configDir,
-    workDir = selected.workDir
+    workDir = selected.workDir,
+    env = env
   )
   if (launchName == null) {
     logger.info("Using default launch '${selected.name}'.")
@@ -1077,6 +1102,9 @@ private fun executeLaunch(
   }
   logCommand(prepared.command)
   val processBuilder = ProcessBuilder(prepared.command)
+  if (context.runtime.env.isNotEmpty()) {
+    processBuilder.environment().putAll(context.runtime.env)
+  }
   val outputLog = logFile?.toAbsolutePath()?.normalize()
   if (outputLog != null) {
     outputLog.parent?.let { Files.createDirectories(it) }

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
@@ -54,7 +54,9 @@ data class LaunchEntry(
   val vmArgs: List<String> = emptyList(),
   val dataDir: String? = null,
   val configDir: String? = null,
-  val workDir: String? = null
+  val workDir: String? = null,
+  val env: Map<String, String> = emptyMap(),
+  val envFile: String? = null
 )
 
 data class TestEntry(
@@ -75,7 +77,8 @@ data class LaunchRuntime(
   val vmArgs: List<String> = emptyList(),
   val dataDir: String? = null,
   val configDir: String? = null,
-  val workDir: String? = null
+  val workDir: String? = null,
+  val env: Map<String, String> = emptyMap()
 )
 
 data class LaunchConfigContext(

--- a/core/pde-launch-engine/src/main/resources/schema/pde.schema.yaml
+++ b/core/pde-launch-engine/src/main/resources/schema/pde.schema.yaml
@@ -78,6 +78,18 @@ $defs:
         description: >-
           Launch working directory override for this launch preset.
           If omitted, a temporary working directory is created.
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        description: >-
+          Extra environment variables for this launch preset. Merged with the
+          current process environment; values here take precedence over envFile.
+      envFile:
+        type: string
+        description: >-
+          Path to a .env file relative to pde.yaml. Each non-blank, non-comment
+          line must be KEY=VALUE. Loaded before inline env, so inline env wins.
     required: [name]
   testEntry:
     type: object

--- a/pde-candidate.schema.yaml
+++ b/pde-candidate.schema.yaml
@@ -95,6 +95,18 @@ $defs:
         description: >-
           Launch working directory override for this launch preset.
           If omitted, a temporary working directory is created.
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        description: >-
+          Extra environment variables for this launch preset. Merged with the
+          current process environment; values here take precedence over envFile.
+      envFile:
+        type: string
+        description: >-
+          Path to a .env file relative to pde.yaml. Each non-blank, non-comment
+          line must be KEY=VALUE. Loaded before inline env, so inline env wins.
     required: [name]
   testEntry:
     type: object


### PR DESCRIPTION
Allows pde.yaml launch entries to specify extra environment variables via an inline `env` map and/or an `envFile` path (relative to pde.yaml). envFile is loaded first; inline env wins on conflict.

With this, it is convenient to let some other app/script generate a "runtime dependent" `.env` file while still making some tweaks manually via the "inline" `env` definition (e.g. setting log levels)