### PR TITLE
Windows Support

### DIFF
--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverTest.kt
@@ -94,7 +94,8 @@ class ResolverTest {
     val result = Resolver.resolve(target, emptyList(), entry)
     val picked = result.bundles.firstOrNull { it.bsn == "b" }
     assertNotNull(picked)
-    assertEquals(listOf(Paths.get("/tmp/b.source-1.0.0")), picked!!.sourceEntries)
+    // sourceEntries are absolutized+normalized by the resolver; mirror that so the assertion is OS-agnostic.
+    assertEquals(listOf(Paths.get("/tmp/b.source-1.0.0").toAbsolutePath().normalize()), picked!!.sourceEntries)
   }
 
   @Test

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
@@ -50,7 +50,8 @@ class CompileServiceTest {
     assertEquals("org.example.test", spec.bsn)
     assertEquals("workspace", spec.origin)
     assertEquals(wsPath.toString(), spec.bundlePath)
-    assertTrue(spec.classpath.contains(wsPath.toString()))
+    // classpath entries are absolutized+normalized by CompileService; mirror that (bundlePath/sourceRoots are raw).
+    assertTrue(spec.classpath.contains(wsPath.toAbsolutePath().normalize().toString()))
     assertTrue(spec.sourceRoots.contains(wsPath.resolve("src").toString()))
     assertEquals(listOf("META-INF/", ".", "icons/"), spec.resourceIncludes)
     assertEquals(listOf("**/*.bak"), spec.resourceExcludes)
@@ -134,7 +135,10 @@ class CompileServiceTest {
 
     val spec = CompileService.buildSpecs(plan, listOf(wsDesc)).specs.first { it.bsn == "org.example.a" }
 
-    assertTrue(spec.classpath.any { it == tpPath.toString() }, "classpath should include target bundle dependency")
+    assertTrue(
+      spec.classpath.contains(tpPath.toAbsolutePath().normalize().toString()),
+      "classpath should include target bundle dependency"
+    )
   }
 
   @Test

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/PlanRewriterTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/PlanRewriterTest.kt
@@ -6,7 +6,6 @@ import org.junit.Test
 import org.osgi.framework.Version
 import java.nio.file.Path
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class PlanRewriterTest {
 
@@ -40,7 +39,9 @@ class PlanRewriterTest {
     val ws = rewritten.bundles.first { it.bsn == "ws.bundle" }
     val tp = rewritten.bundles.first { it.bsn == "tp.bundle" }
 
-    assertTrue(ws.location.toString().endsWith("/ws/ws.bundle/bin"), "workspace bundle should point to compiled output")
-    assertEquals("/tp/tp.bundle", tp.location.toString())
+    // Compare Path objects (not OS-specific strings): the workspace location is the rewritten,
+    // absolutized+normalized output dir; the target bundle is untouched.
+    assertEquals(Path.of("/ws/ws.bundle/bin").toAbsolutePath().normalize(), ws.location)
+    assertEquals(Path.of("/tp/tp.bundle"), tp.location)
   }
 }

--- a/tools/target-installer/META-INF/MANIFEST.MF
+++ b/tools/target-installer/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Target Platform Installer
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-SymbolicName: org.knime.targetinstaller;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: ., lib/tinylog-impl-2.7.0.jar, lib/tinylog-api-2.7.0.jar

--- a/tools/target-installer/scripts/build-launcher.sh
+++ b/tools/target-installer/scripts/build-launcher.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Windows/Git-Bash: convert the MSYS path (/c/...) to mixed form (C:/...) so the
+# Windows JDK tools (javac/java/jar) and Equinox understand the derived paths.
+if command -v cygpath >/dev/null 2>&1; then
+  REPO_ROOT="$(cygpath -m "$REPO_ROOT")"
+fi
 BUILD_DIR="$REPO_ROOT/build"
 PLUGIN_BUILD_DIR="$BUILD_DIR/plugin"
 PLUGIN_DIR="$PLUGIN_BUILD_DIR/plugins"
@@ -18,6 +23,19 @@ P2_REPOSITORIES="${P2_REPOSITORIES:-}"
 RUNTIME_ZIP="${RUNTIME_ZIP:-}"
 JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
 JAVAC_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}javac"
+
+# Platform portability: classpath separator and file-URL form differ on Windows.
+CPSEP=":"
+FILEURL="file:"
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*)
+    CPSEP=";"            # ':' collides with C: drive letters on Windows
+    FILEURL="file:/"     # Equinox needs file:/C:/... (with leading slash)
+    ;;
+esac
+if [[ -n "${ECLIPSE_SDK:-}" ]] && command -v cygpath >/dev/null 2>&1; then
+  ECLIPSE_SDK="$(cygpath -m "$ECLIPSE_SDK")"
+fi
 
 TINYLOG_VERSION="2.7.0"
 PLUGIN_VERSION=$(grep "^Bundle-Version:" "$REPO_ROOT/META-INF/MANIFEST.MF" | awk '{print $2}' | tr -d '\r' | sed 's/\.qualifier$//')
@@ -51,13 +69,23 @@ download_dep "https://repo1.maven.org/maven2/org/tinylog/tinylog-api/${TINYLOG_V
 download_dep "https://repo1.maven.org/maven2/org/tinylog/tinylog-impl/${TINYLOG_VERSION}/tinylog-impl-${TINYLOG_VERSION}.jar" \
   "$LIB_DIR/tinylog-impl-${TINYLOG_VERSION}.jar"
 
-CLASSPATH=$(printf "%s:" "$ECLIPSE_PLUGINS_DIR"/*.jar)
-CLASSPATH+="$LIB_DIR/tinylog-api-${TINYLOG_VERSION}.jar:$LIB_DIR/tinylog-impl-${TINYLOG_VERSION}.jar"
+CLASSPATH=$(printf "%s${CPSEP}" "$ECLIPSE_PLUGINS_DIR"/*.jar)
+CLASSPATH+="$LIB_DIR/tinylog-api-${TINYLOG_VERSION}.jar${CPSEP}$LIB_DIR/tinylog-impl-${TINYLOG_VERSION}.jar"
 
 echo "Compiling bundle"
-"$JAVAC_BIN" --release 17 -cp "$CLASSPATH" \
-  -d "$PLUGIN_BUILD_DIR/classes" \
-  $(find "$REPO_ROOT/src" -name '*.java')
+# Pass options/sources via an @argfile: the full classpath (~700 SDK jars) plus the
+# source list exceeds the OS command-line length limit ("Argument list too long").
+JAVAC_ARGS="$BUILD_DIR/javac-bundle-args.txt"
+{
+  echo "--release"
+  echo "17"
+  echo "-cp"
+  printf '"%s"\n' "$CLASSPATH"
+  echo "-d"
+  printf '"%s"\n' "$PLUGIN_BUILD_DIR/classes"
+  find "$REPO_ROOT/src" -name '*.java' | while IFS= read -r f; do printf '"%s"\n' "$f"; done
+} > "$JAVAC_ARGS"
+"$JAVAC_BIN" "@$JAVAC_ARGS"
 
 echo "Packaging bundle"
 jar cfm "$PLUGIN_DIR/$PLUGIN_JAR" \
@@ -85,27 +113,53 @@ else
     exit 1
   fi
 
-  echo "Publishing p2 repository"
+  echo "Publishing p2 repository (target-installer plugin)"
   "$JAVA_BIN" -jar "$LAUNCHER_JAR" \
     -application org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher \
-    -metadataRepository "file:$REPO_DIR" \
-    -artifactRepository "file:$REPO_DIR" \
+    -metadataRepository "${FILEURL}$REPO_DIR" \
+    -artifactRepository "${FILEURL}$REPO_DIR" \
     -source "$PLUGIN_BUILD_DIR" \
     -compress -publishArtifacts
 
-  REPOS="file:$REPO_DIR"
+  # Publish the Eclipse SDK into a local p2 repo so the runtime IUs (felix.scr,
+  # equinox p2 touchpoints, ...) resolve deterministically offline, independent of
+  # remote release-repo availability / p2 transport-proxy quirks.
+  SDK_REPO_DIR="$BUILD_DIR/sdk-p2repo"
+  echo "Publishing p2 repository (Eclipse SDK)"
+  "$JAVA_BIN" -jar "$LAUNCHER_JAR" \
+    -application org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher \
+    -metadataRepository "${FILEURL}$SDK_REPO_DIR" \
+    -artifactRepository "${FILEURL}$SDK_REPO_DIR" \
+    -source "$ECLIPSE_SDK" \
+    -compress -publishArtifacts
+
+  REPOS="${FILEURL}$REPO_DIR,${FILEURL}$SDK_REPO_DIR"
   if [[ -n "$P2_REPOSITORIES" ]]; then
     REPOS+="${REPOS:+,}$P2_REPOSITORIES"
+  fi
+
+  # org.eclipse.osgi.services was removed in newer Eclipse (its packages are folded
+  # into org.eclipse.osgi); include the IU only when the SDK still ships it.
+  INSTALL_IUS="org.knime.targetinstaller,org.apache.felix.scr,org.eclipse.equinox.p2.transport.ecf,org.eclipse.equinox.p2.touchpoint.natives,org.eclipse.equinox.p2.touchpoint.eclipse,org.eclipse.equinox.frameworkadmin,org.eclipse.equinox.frameworkadmin.equinox,org.eclipse.equinox.simpleconfigurator.manipulator,org.eclipse.osgi.compatibility.state"
+  if ls "$ECLIPSE_PLUGINS_DIR"/org.eclipse.osgi.services_*.jar >/dev/null 2>&1; then
+    INSTALL_IUS+=",org.eclipse.osgi.services"
   fi
 
   echo "Materializing runtime"
   "$JAVA_BIN" -jar "$LAUNCHER_JAR" \
     -application org.eclipse.equinox.p2.director \
     -repository "$REPOS" \
-    -installIU org.knime.targetinstaller,org.apache.felix.scr,org.eclipse.equinox.p2.transport.ecf,org.eclipse.equinox.p2.touchpoint.natives,org.eclipse.equinox.p2.touchpoint.eclipse,org.eclipse.equinox.frameworkadmin,org.eclipse.equinox.frameworkadmin.equinox,org.eclipse.equinox.simpleconfigurator.manipulator,org.eclipse.osgi.compatibility.state,org.eclipse.osgi.services \
+    -installIU "$INSTALL_IUS" \
     -destination "$RUNTIME_DIR" \
     -profile DefaultProfile \
     -bundlepool "$RUNTIME_DIR"
+
+  # The Equinox launcher exits 0 even when the director reports "Installation failed",
+  # so verify the target-installer plugin actually landed in the runtime.
+  if ! ls "$RUNTIME_DIR"/plugins/org.knime.targetinstaller_*.jar >/dev/null 2>&1; then
+    echo "Runtime materialization failed: org.knime.targetinstaller missing from $RUNTIME_DIR/plugins" >&2
+    exit 1
+  fi
 
   echo "Adding Equinox launcher"
   mkdir -p "$RUNTIME_DIR/plugins"

--- a/tools/target-installer/scripts/build-launcher.sh
+++ b/tools/target-installer/scripts/build-launcher.sh
@@ -78,7 +78,7 @@ echo "Compiling bundle"
 JAVAC_ARGS="$BUILD_DIR/javac-bundle-args.txt"
 {
   echo "--release"
-  echo "17"
+  echo "21"
   echo "-cp"
   printf '"%s"\n' "$CLASSPATH"
   echo "-d"
@@ -176,7 +176,7 @@ echo "Creating runtime archive"
 jar cf "$LAUNCHER_BUILD_DIR/runtime.zip" -C "$RUNTIME_DIR" .
 
 echo "Building launcher"
-"$JAVAC_BIN" --release 17 \
+"$JAVAC_BIN" --release 21 \
   -d "$LAUNCHER_BUILD_DIR/classes" \
   "$REPO_ROOT/launcher/src/org/knime/targetinstaller/launcher/Bootstrap.java"
 

--- a/tools/target-installer/scripts/build-launcher.sh
+++ b/tools/target-installer/scripts/build-launcher.sh
@@ -55,6 +55,15 @@ if [[ -z "$ECLIPSE_PLUGINS_DIR" ]]; then
   ECLIPSE_PLUGINS_DIR="$BOOTSTRAP_RUNTIME_DIR/plugins"
 fi
 
+# Fail fast on a bad SDK/runtime path. The "$ECLIPSE_PLUGINS_DIR"/*.jar glob below has no nullglob,
+# so an unmatched pattern falls through as a literal and javac then emits 100+ misleading
+# "package org.eclipse.* does not exist" errors instead of a clear cause.
+if [[ ! -d "$ECLIPSE_PLUGINS_DIR" ]] || ! compgen -G "$ECLIPSE_PLUGINS_DIR/*.jar" >/dev/null; then
+  echo "ERROR: no Eclipse plugin jars found in '$ECLIPSE_PLUGINS_DIR'." >&2
+  echo "       Point ECLIPSE_SDK (or the 'eclipseSdk' Gradle property) at a real Eclipse SDK install." >&2
+  exit 1
+fi
+
 function download_dep() {
   local url="$1"
   local out="$2"


### PR DESCRIPTION
## Windows / Git-Bash build support, OS-agnostic tests, Java 21 target-installer

Build and test portability and hardening, all touching `build-launcher.sh` and the resolver test suite. The cross-platform shell changes are gated on the platform, so Linux/macOS builds are unchanged.

### `build-launcher.sh`: Windows / Git Bash

Run the target-installer build under Git Bash on Windows:

- `cygpath -m` to convert MSYS paths (`/c/...`) to the mixed form (`C:/...`) the Windows JDK tools and Equinox expect.
- platform-correct classpath separator (`;` on Windows, since `:` collides with drive letters).
- `file:/` p2 URLs (Equinox needs the leading slash on Windows).
- pass javac options and sources via an `@argfile` (the ~700-jar SDK classpath plus the source list exceeds the Windows command-line length limit).

Alongside, a few build-robustness fixes that were needed to get a clean run: publish the SDK to a local p2 repo for deterministic offline resolution, include the `org.eclipse.osgi.services` IU only when the SDK still ships it (removed in newer Eclipse), and fail if the p2 director reports success but the plugin did not actually materialize.

### OS-agnostic resolver tests

`ResolverTest`, `CompileServiceTest`, and `PlanRewriterTest` compared hard-coded POSIX path strings and so failed on Windows. They now compare normalized `Path` objects, so the suite passes regardless of OS.

### target-installer: build for Java 21

Compile `--release 21` and declare `Bundle-RequiredExecutionEnvironment: JavaSE-21`, to match pde's existing Java 21 baseline (all Kotlin modules already use `jvmToolchain(21)`). It now requires a 21+ JRE to run, which is fine: it runs inside the Eclipse SDK JVM, which is already on 21.

### Fail fast on a missing Eclipse SDK

A wrong or empty `ECLIPSE_SDK` left the unmatched `"$ECLIPSE_PLUGINS_DIR"/*.jar` glob on javac's classpath as a literal, producing 100+ misleading "package org.eclipse.* does not exist" errors. The build now validates the plugins directory up front and exits with one clear message.