### PR TITLE
Resolver and Launch Fixes

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -2612,6 +2612,25 @@ private fun prepareLaunch(
   return PreparedLaunch(command, planResult, layout)
 }
 
+/**
+ * A fragment bundle has no classloader of its own, so the PDE test runner's
+ * `bundle.loadClass(testClass)` throws "Can not load a class from a fragment bundle". When
+ * `-testpluginname` names a fragment, rewrite it to the fragment's host (e.g.
+ * `org.knime.core.workflow.tests` -> `org.knime.core`); the host's classloader loads the
+ * fragment's classes.
+ */
+private fun rewriteFragmentTestPluginNameToHost(
+  programArgs: MutableList<String>,
+  planResult: LaunchPlanner.PlanResult
+) {
+  val idx = programArgs.indexOf("-testpluginname")
+  if (idx < 0 || idx + 1 >= programArgs.size) return
+  val bsn = programArgs[idx + 1]
+  val host = planResult.selectedBundles.firstOrNull { it.bsn == bsn }?.fragmentHost ?: return
+  logger.info("-testpluginname '$bsn' is a fragment; using host '$host' so its classes can be loaded.")
+  programArgs[idx + 1] = host
+}
+
 private fun assembleCommand(
   context: LaunchConfigContext,
   layout: LaunchLayout,
@@ -2633,6 +2652,7 @@ private fun assembleCommand(
     addAll(targetArgs?.programArgs ?: emptyList())
     addAll(configProgramArgs)
   }
+  rewriteFragmentTestPluginNameToHost(programArgs, planResult)
   val stdArgs = mutableListOf<String>().apply {
     if (context.clean) {
       add("-clean")

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -18,6 +18,7 @@ import cn.varsa.pde.remoterunner.parsePortRange
 import cn.varsa.pde.remoterunner.parseReportTarget
 import cn.varsa.pde.remoterunner.startForwarders
 import cn.varsa.pde.resolver.algo.ResolveOptions
+import cn.varsa.pde.resolver.algo.Resolver
 import cn.varsa.pde.resolver.algo.WorkspaceBundleDescriptor
 import cn.varsa.pde.resolver.api.AnalyzerBundleArtifact
 import cn.varsa.pde.resolver.api.BatchApiAnalyzerInput
@@ -4478,7 +4479,16 @@ fun compileMain(args: Array<String>): Int {
     )
     val planResult = LaunchPlanner.build(env, options)
     logPlanSummary(planResult)
-    val specs = CompileService.buildSpecs(planResult, workspaceInputs.descriptors)
+    // Each workspace bundle compiles against its OWN resolved closure (its declared Require-Bundle
+    // ranges), not the aggregate union of every bundle's closure -- which can carry several versions
+    // of a multi-version library (e.g. Guava 19 and 33) and make ecj bind an overload the bundle
+    // won't have at runtime (compile/launch version skew -> NoSuchMethodError).
+    val perEntryClasspath: Map<String, List<String>> = workspaceInputs.descriptors.mapNotNull { desc ->
+      val bsn = desc.manifest.bundleSymbolicName?.key ?: return@mapNotNull null
+      val res = Resolver.resolve(targetIndex, workspaceInputs.descriptors, desc, env.resolverOptions)
+      bsn to res.bundles.flatMap { it.classPathEntries }.map { it.toAbsolutePath().normalize().toString() }
+    }.toMap()
+    val specs = CompileService.buildSpecs(planResult, workspaceInputs.descriptors, perEntryClasspath)
       .specs
       .map { spec ->
         val withDebug = if (debugInfo && spec.isWorkspace) {

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
@@ -254,8 +254,8 @@ object LaunchConfigLoader {
 internal val DEFAULT_STARTUP_LEVELS = mapOf(
   "org.eclipse.osgi" to 1,
   "org.eclipse.equinox.simpleconfigurator" to 1,
-  "org.eclipse.equinox.ds" to 1,
-  "org.eclipse.m2e.logback.configuration" to 4,
+  // DS runtime is org.apache.felix.scr (below); org.eclipse.equinox.ds was removed from modern
+  // Eclipse. org.eclipse.m2e.logback.configuration is an IDE-only bundle absent from real targets.
   "org.apache.felix.gogo.runtime" to 4,
   "org.eclipse.equinox.event" to 2,
   "org.eclipse.core.runtime" to 4,

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/BundleSelectionAccumulator.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/BundleSelectionAccumulator.kt
@@ -49,6 +49,9 @@ class BundleSelectionAccumulator(private val preferWorkspace: Boolean = true) {
     isWorkspace: Boolean = false,
     classPathEntries: List<Path> = listOf(path)
   ) {
+    // Note: supplemental (whole-target) bundles are intentionally NOT armed for lazy activation —
+    // only the workspace resolver closure is (see LaunchPlanner). Arming the whole target caused a
+    // startup activation storm of unrelated bundles (birt/h2o/debug.ui) in headless test launches.
     register(
       ResolvedBundle(
         bsn = bsn,

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
@@ -6,6 +6,7 @@ import cn.varsa.pde.resolver.manifest.BundleManifest
 import cn.varsa.pde.resolver.manifest.exportedPackageAndVersion
 import cn.varsa.pde.resolver.manifest.fragmentHostAndVersionRange
 import cn.varsa.pde.resolver.manifest.importedPackageAndVersion
+import cn.varsa.pde.resolver.manifest.isLazyActivated
 import cn.varsa.pde.resolver.manifest.requiredBundleAndVersion
 import cn.varsa.pde.resolver.manifest.reexportRequiredBundleAndVersion
 import org.osgi.framework.Version
@@ -65,7 +66,9 @@ data class ResolvedBundle(
   val sourceEntries: List<Path> = emptyList(),
   val fragmentHost: String? = null,
   val isHost: Boolean = false,
-  val reexport: Boolean = false
+  val reexport: Boolean = false,
+  /** Bundle declares `Bundle-ActivationPolicy: lazy` — must be armed (started) for DS/activator to run. */
+  val lazyActivation: Boolean = false
 ) {
   val isWorkspace: Boolean get() = origin == BundleOrigin.WORKSPACE
 }
@@ -435,7 +438,8 @@ object Resolver {
       classPathEntries = c.classPathEntries,
       sourceEntries = c.sourceEntries,
       fragmentHost = c.fragmentHost,
-      isHost = c.isHost
+      isHost = c.isHost,
+      lazyActivation = c.manifest.isLazyActivated()
     )
 
     val bundles = mutableListOf<ResolvedBundle>()

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
@@ -211,29 +211,48 @@ object Resolver {
       }
     }
 
+    // Expand a Require-Bundle closure. Selection is "first constraint wins", with selection split
+    // from recursion (via `closureProcessed`) so a bundle pre-selected in phase 1 below still has
+    // its own requires expanded.
+    val closureProcessed = HashSet<String>()
     fun addRequireWithClosure(bsn: String, range: VersionRange) {
       if (!selected.containsKey(bsn)) {
         val cand = select(bsn, range)
-        if (cand != null) {
-          selected.putIfAbsent(bsn, cand)
-          val requiresAll = if (cand.origin == BundleOrigin.WORKSPACE) {
-            cand.manifest.requiredBundleAndVersion(includeOptional = true) +
-              cand.manifest.reexportRequiredBundleAndVersion(includeOptional = true)
-          } else {
-            val nav = target.requiresByBundle()[cand.bsn]?.get(cand.version) ?: emptyMap()
-            nav + cand.manifest.reexportRequiredBundleAndVersion(includeOptional = true)
-          }
-          requiresAll.forEach { (childBsn, childRange) -> addRequireWithClosure(childBsn, childRange) }
-        } else {
+        if (cand == null) {
           unresolved.add(UnresolvedBundle(bsn, range, "require-bundle"))
+          return
         }
+        selected[bsn] = cand
       }
+      if (!closureProcessed.add(bsn)) return
+      val cand = selected[bsn] ?: return
+      val requiresAll = if (cand.origin == BundleOrigin.WORKSPACE) {
+        cand.manifest.requiredBundleAndVersion(includeOptional = true) +
+          cand.manifest.reexportRequiredBundleAndVersion(includeOptional = true)
+      } else {
+        val nav = target.requiresByBundle()[cand.bsn]?.get(cand.version) ?: emptyMap()
+        nav + cand.manifest.reexportRequiredBundleAndVersion(includeOptional = true)
+      }
+      requiresAll.forEach { (childBsn, childRange) -> addRequireWithClosure(childBsn, childRange) }
     }
 
     val requires = LinkedHashMap(entry.manifest.requiredBundleAndVersion(includeOptional = true))
     fragmentHostCandidate?.manifest?.requiredBundleAndVersion(includeOptional = true)?.forEach { (bsn, range) ->
       requires.putIfAbsent(bsn, range)
     }
+    // Phase 1: lock the entry's (and fragment host's) DIRECT Require-Bundle constraints at their own
+    // ranges before expanding the transitive closure. When the target ships several versions of a
+    // library, a transitive path that requires it at a wider range (e.g. another bundle wanting
+    // Guava 33 while this one declares `[19,20)`) would otherwise grab the global-highest version
+    // first, and this bundle would compile against a newer library than its declared range binds at
+    // launch -> NoSuchMethodError. Equinox wires each bundle to its own range, so the compile
+    // classpath must match.
+    requires.forEach { (bsn, range) ->
+      if (!selected.containsKey(bsn)) {
+        select(bsn, range)?.let { selected[bsn] = it }
+      }
+    }
+    // Phase 2: expand the full transitive closure (recurses even into phase-1-selected bundles).
     requires.forEach { (bsn, range) -> addRequireWithClosure(bsn, range) }
 
     val imports = LinkedHashMap(entry.manifest.importedPackageAndVersion())

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/algo/Resolver.kt
@@ -43,6 +43,19 @@ data class ResolveOptions(
 
 enum class BundleOrigin { WORKSPACE, TARGET }
 
+/**
+ * Packages provided by the JRE / OSGi system bundle (boot classpath), never exported by a regular
+ * bundle. The indirect-import closure must skip these — otherwise it records hundreds of bogus
+ * `import-package-indirect` unresolved entries for `javax.*`/`jdk.*`/etc.
+ */
+private val SYSTEM_PACKAGE_PREFIXES = listOf(
+  "java.", "javax.", "jakarta.", "jdk.", "sun.", "com.sun.",
+  "org.w3c.dom", "org.xml.sax", "org.ietf.jgss", "org.omg."
+)
+
+internal fun isSystemPackage(pkg: String): Boolean =
+  SYSTEM_PACKAGE_PREFIXES.any { pkg == it.trimEnd('.') || pkg.startsWith(it) }
+
 data class ResolvedBundle(
   val bsn: String,
   val version: Version,
@@ -294,30 +307,6 @@ object Resolver {
       map
     }
 
-    val importedPkgs = imports.keys
-    val tpProvidersByPkg: Map<String, java.util.NavigableMap<Version, PkgProvider>> = run {
-      val map = HashMap<String, java.util.NavigableMap<Version, PkgProvider>>()
-      val byPkg = target.exportedBundlesByPackageNav()
-      importedPkgs.forEach { pkg ->
-        val nav = byPkg[pkg] ?: return@forEach
-        val providers = java.util.TreeMap<Version, PkgProvider>()
-        nav.forEach { (ver, rb) ->
-          val bsn = rb.manifest.bundleSymbolicName?.key ?: return@forEach
-          providers[ver] = PkgProvider(
-            bsn,
-            ver,
-            rb.location,
-            rb.manifest,
-            BundleOrigin.TARGET,
-            computeTargetClassPathEntries(rb, target),
-            computeTargetSourceEntries(rb, target)
-          )
-        }
-        if (providers.isNotEmpty()) map[pkg] = providers
-      }
-      map
-    }
-
     fun providerToCandidate(provider: PkgProvider) = Candidate(
       bsn = provider.bsn,
       version = provider.version,
@@ -329,13 +318,21 @@ object Resolver {
       fragmentHost = provider.manifest.fragmentHost?.key
     )
 
-    fun pinnedProviderCandidate(provider: PkgProvider, pkg: String, range: VersionRange): Candidate? {
-      val pinnedVersion = options.pinnedVersions[provider.bsn] ?: return providerToCandidate(provider)
-      val pinned = selectExact(provider.bsn, pinnedVersion) ?: return null
+    // If the provider's BSN is pinned, the pinned version replaces the candidate — but only if
+    // it still exports the package within the requested range; otherwise the candidate is
+    // rejected (a pin must not silently satisfy an import it cannot actually provide).
+    fun applyPin(candidate: Candidate, pkg: String, range: VersionRange): Candidate? {
+      val pinnedVersion = options.pinnedVersions[candidate.bsn] ?: return candidate
+      val pinned = selectExact(candidate.bsn, pinnedVersion) ?: return null
       val exported = exportsOf(pinned.manifest)[pkg] ?: return null
       return if (range.includes(exported)) pinned else null
     }
 
+    // Provider of an imported package: workspace exporters first, then target exporters ordered
+    // by bundle version descending (symbolic name as deterministic tie-break). The target lookup
+    // enumerates EVERY exporter of the package — unlike a version-keyed map, two bundles
+    // exporting the same package at the same bundle version don't shadow each other; the first
+    // whose export version satisfies the range (and survives pinning) wins.
     fun findProviderForPackage(pkg: String, range: VersionRange): Candidate? {
       if (options.preferWorkspace) {
         val ws = wsProvidersByPkg[pkg]
@@ -346,26 +343,79 @@ object Resolver {
           }
           ?.maxByOrNull { it.version }
         if (ws != null) {
-          val pinned = pinnedProviderCandidate(ws, pkg, range)
+          val pinned = applyPin(providerToCandidate(ws), pkg, range)
           if (pinned != null) return pinned
         }
       }
 
-      val nav = tpProvidersByPkg[pkg] ?: return null
-      val provider = nav.descendingMap().entries.asSequence().mapNotNull { e ->
-        val man = e.value.manifest
-        val ver = exportsOf(man)[pkg]
-        if (ver != null && range.includes(ver)) pinnedProviderCandidate(e.value, pkg, range) else null
+      val providers = target.exportedBundlesByPackage()[pkg] ?: return null
+      return providers.asSequence().mapNotNull { rb ->
+        val exported = exportsOf(rb.manifest)[pkg] ?: return@mapNotNull null
+        if (!range.includes(exported)) return@mapNotNull null
+        applyPin(candidateFromTarget(rb), pkg, range)
       }.firstOrNull()
-      return provider
     }
 
-    imports.forEach { (pkg, range) ->
-      val provider = findProviderForPackage(pkg, range)
-      if (provider != null && !selected.containsKey(provider.bsn)) {
-        selected[provider.bsn] = provider
-      } else if (provider == null) {
-        unresolved.add(UnresolvedBundle(pkg, range, "import-package"))
+    // Requirements-closure fixpoint, approximating Eclipse PDE's
+    // DependencyManager.findRequirementsClosure: every selected bundle's Import-Package,
+    // Require-Bundle, and Fragment-Host dependencies are followed until the selection is stable,
+    // so e.g. junit-jupiter-api -> org.opentest4j (a package a closure member only Imports) lands
+    // on the compile classpath instead of ecj reporting "indirectly referenced from required
+    // type". Unlike Eclipse PDE there is no resolved Equinox wiring state to read exporters from,
+    // so each package's provider is re-derived (workspace first, pins honored, then highest
+    // in-range export). An import is satisfied only by its resolved provider: an unrelated
+    // selected bundle exporting the same package does not mask it — if the provider is already
+    // selected nothing is added, otherwise it joins the selection. Optional imports are followed
+    // like Eclipse PDE's INCLUDE_OPTIONAL_DEPENDENCIES build closure; an unsatisfiable optional
+    // import is skipped silently. Unsatisfiable JRE/system-package imports (java./jdk./...) are
+    // also skipped silently — they come from the OSGi system bundle via boot delegation, so their
+    // absence from the target index is expected — but a bundle-provided javax.* package (e.g.
+    // javax.servlet) still resolves normally because providers are looked up before the check.
+    run {
+      val processed = HashSet<String>()
+      while (true) {
+        val pending = selected.keys.filter { it !in processed }
+        if (pending.isEmpty()) break
+        pending.forEach { bsn ->
+          processed.add(bsn)
+          val cand = selected[bsn] ?: return@forEach
+          val manifest = cand.manifest
+
+          // A fragment pulled into the closure needs its host on the classpath (the entry's own
+          // host was already handled above, gated by includeHostsForFragments).
+          if (bsn != entrySymbolicName) {
+            manifest.fragmentHostAndVersionRange()?.let { (hostBsn, hostRange) ->
+              if (!selected.containsKey(hostBsn)) {
+                val host = select(hostBsn, hostRange)
+                if (host != null) selected[hostBsn] = host
+                else unresolved.add(UnresolvedBundle(hostBsn, hostRange, "fragmentHost"))
+              }
+            }
+          }
+
+          // Bundles that entered the selection via Import-Package still bring their own
+          // Require-Bundle closure (idempotent for bundles the require phase already expanded).
+          addRequireWithClosure(bsn, exactVersionRange(cand.version))
+
+          val mandatoryImports = manifest.importedPackageAndVersion()
+          manifest.importedPackageAndVersion(includeOptional = true).forEach forEachPkg@{ (pkg, range) ->
+            val provider = findProviderForPackage(pkg, range)
+            if (provider == null) {
+              if (pkg in mandatoryImports && !isSystemPackage(pkg)) {
+                val reason =
+                  if (bsn == entrySymbolicName || bsn == hostPair?.first) "import-package"
+                  else "import-package-indirect"
+                unresolved.add(UnresolvedBundle(pkg, range, reason))
+              }
+              return@forEachPkg
+            }
+            // Only the resolved provider satisfies the import; if it is already selected
+            // (possibly at another version — consistency first) there is nothing to add.
+            if (!selected.containsKey(provider.bsn)) {
+              selected[provider.bsn] = provider
+            }
+          }
+        }
       }
     }
 
@@ -427,7 +477,7 @@ object Resolver {
     val problems = directProblems + unresolved.map { u ->
       val type = when (u.reason) {
         "fragmentHost" -> ResolveProblemType.FRAGMENT_HOST
-        "import-package" -> ResolveProblemType.MISSING_PACKAGE
+        "import-package", "import-package-indirect" -> ResolveProblemType.MISSING_PACKAGE
         else -> ResolveProblemType.MISSING_BUNDLE
       }
       ResolveProblem(type, u.bsn, u.range, u.reason)

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileService.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileService.kt
@@ -12,12 +12,23 @@ object CompileService {
 
   data class Output(val specs: List<CompileSpec>)
 
-  fun buildSpecs(plan: LaunchPlanner.PlanResult, workspace: List<WorkspaceBundleDescriptor>): Output {
+  /**
+   * @param perEntryClasspath optional per-workspace-bundle compile classpath (BSN -> entries),
+   *   each derived from that bundle's OWN resolve closure. When present for a workspace bundle, it
+   *   is used instead of the aggregate union of all bundles' closures, so a bundle compiles against
+   *   the library versions its own ranges select (matching its launch wiring). Falls back to the
+   *   union when absent.
+   */
+  fun buildSpecs(
+    plan: LaunchPlanner.PlanResult,
+    workspace: List<WorkspaceBundleDescriptor>,
+    perEntryClasspath: Map<String, List<String>> = emptyMap()
+  ): Output {
     val byPath = workspace.associateBy { it.path.toAbsolutePath().normalize() }
     val allClassPathEntries: List<String> = plan.selectedBundles
       .flatMap { it.classPathEntries }
       .map { it.toAbsolutePath().normalize().toString() }
-    val specs = plan.selectedBundles.map { rb -> toSpec(rb, byPath, allClassPathEntries) }
+    val specs = plan.selectedBundles.map { rb -> toSpec(rb, byPath, allClassPathEntries, perEntryClasspath) }
     val ordered = orderWorkspaceSpecs(specs, plan.workspaceDependencies)
     return Output(ordered)
   }
@@ -68,14 +79,20 @@ object CompileService {
   private fun toSpec(
     rb: ResolvedBundle,
     byPath: Map<java.nio.file.Path, WorkspaceBundleDescriptor>,
-    allClassPathEntries: List<String>
+    allClassPathEntries: List<String>,
+    perEntryClasspath: Map<String, List<String>>
   ): CompileSpec {
     val w = if (rb.isWorkspace) byPath[rb.path.toAbsolutePath().normalize()] else null
     val effectiveClasspath = linkedSetOf<String>().apply {
       // Prefer bundle-specific classPathEntries first (bin includes, Bundle-ClassPath)
       addAll(rb.classPathEntries.map { it.toAbsolutePath().normalize().toString() })
-      // Then add all resolved bundle locations (workspace + TP) for dependencies
-      addAll(allClassPathEntries)
+      // A workspace bundle compiles against ITS OWN resolved closure (honoring its declared
+      // Require-Bundle ranges) when one is supplied, not the global union of every bundle's closure.
+      // The union can carry several versions of a multi-version library, which makes ecj bind an
+      // overload the bundle won't have at runtime. Falls back to the union when no per-entry
+      // classpath is provided.
+      val own = if (rb.isWorkspace) perEntryClasspath[rb.bsn] else null
+      addAll(own ?: allClassPathEntries)
     }.toList()
     return CompileSpec(
       bsn = rb.bsn,

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/index/TargetPlatformIndex.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/index/TargetPlatformIndex.kt
@@ -61,8 +61,15 @@ class TargetPlatformIndex(
       }
     }
 
-    // Optional: order per package by bundle version descending (cheap heuristic)
-    map.replaceAll { _, list -> list.sortedByDescending { it.manifest.bundleVersion } as MutableList<ResolvedBundle> }
+    // Order per package by bundle version descending; tie-break on symbolic name so two
+    // different bundles exporting the same package at the same bundle version enumerate in a
+    // deterministic order (byBsn is hash-ordered, and a stable sort alone would leak that).
+    map.replaceAll { _, list ->
+      list.sortedWith(
+        compareByDescending<ResolvedBundle> { it.manifest.bundleVersion }
+          .thenBy { it.manifest.bundleSymbolicName?.key ?: "" }
+      ) as MutableList<ResolvedBundle>
+    }
 
     exportsByPackage = map
     exportsByPackageNav = null

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/launch/LaunchPlanner.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/launch/LaunchPlanner.kt
@@ -96,7 +96,9 @@ object LaunchPlanner {
 
     val bundles = selector.entries().map { rb ->
       val level = levelFor(rb.bsn)
-      val auto = autoStartFor(rb.bsn, level)
+      // Lazy-activation bundles must be armed (started with the activation policy) or Equinox never
+      // runs their activator / DS components. Force auto-start for them regardless of autoStartDefault.
+      val auto = autoStartFor(rb.bsn, level) || rb.lazyActivation
       startupLevels[rb.bsn] = level
       BundleStartSpec(
         bsn = rb.bsn,

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/manifest/BundleManifestExt.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/manifest/BundleManifestExt.kt
@@ -4,6 +4,8 @@ import cn.varsa.pde.resolver.support.VersionRangeAny
 import cn.varsa.pde.resolver.support.contains
 import cn.varsa.pde.resolver.support.parseVersion
 import cn.varsa.pde.resolver.support.parseVersionRange
+import org.osgi.framework.Constants.ACTIVATION_LAZY
+import org.osgi.framework.Constants.BUNDLE_ACTIVATIONPOLICY
 import org.osgi.framework.Constants.BUNDLE_VERSION_ATTRIBUTE
 import org.osgi.framework.Constants.RESOLUTION_DIRECTIVE
 import org.osgi.framework.Constants.RESOLUTION_OPTIONAL
@@ -16,6 +18,14 @@ fun BundleManifest.fragmentHostAndVersionRange(): Pair<String, VersionRange>? =
 
 val BundleManifest.canonicalName: String
   get() = "${bundleSymbolicName?.key}-${bundleVersion}"
+
+/**
+ * True if the bundle declares `Bundle-ActivationPolicy: lazy`. Such bundles must be *started* (with
+ * the activation policy) for Equinox to arm lazy activation — otherwise their `BundleActivator` and
+ * DS components never run. The launch planner uses this to auto-start (arm) lazy bundles.
+ */
+fun BundleManifest.isLazyActivated(): Boolean =
+  this[BUNDLE_ACTIVATIONPOLICY]?.substringBefore(";")?.trim().equals(ACTIVATION_LAZY, ignoreCase = true)
 
 fun BundleManifest.isFragmentHost(
   fragmentHostBSN: String,

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/manifest/BundleManifestExt.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/manifest/BundleManifestExt.kt
@@ -56,8 +56,8 @@ fun BundleManifest.reexportRequiredBundleAndVersion(includeOptional: Boolean = f
   requireBundle?.clauses(includeOptional)?.filter { it.value.directive["visibility"] == "reexport" }
     ?.mapValues { (_, attrs) -> attrs.attribute[BUNDLE_VERSION_ATTRIBUTE].parseVersionRange() } ?: emptyMap()
 
-fun BundleManifest.importedPackageAndVersion(): Map<String, VersionRange> =
-  importPackage?.mandatoryClauses()
+fun BundleManifest.importedPackageAndVersion(includeOptional: Boolean = false): Map<String, VersionRange> =
+  importPackage?.clauses(includeOptional)
     ?.mapValues { (_, attrs) -> attrs.attribute[VERSION_ATTRIBUTE].parseVersionRange() } ?: emptyMap()
 
 fun BundleManifest.exportedPackageAndVersion(): Map<String, Version> =

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverIndirectImportTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverIndirectImportTest.kt
@@ -1,0 +1,230 @@
+package cn.varsa.pde.resolver.algo
+
+import cn.varsa.pde.resolver.index.ResolvedBundle
+import cn.varsa.pde.resolver.index.TargetPlatformIndex
+import cn.varsa.pde.resolver.manifest.BundleManifest
+import org.junit.Assert.*
+import org.junit.Test
+import org.osgi.framework.Version
+import java.nio.file.Paths
+import java.util.*
+
+class ResolverIndirectImportTest {
+
+  private fun bm(vararg pairs: Pair<String, String>) = BundleManifest.parse(mapOf(*pairs))
+
+  private fun tpBundle(bsn: String, vararg headers: Pair<String, String>): ResolvedBundle {
+    val manifest = bm(*headers)
+    return ResolvedBundle(Paths.get("/tp/plugins/$bsn"), manifest, true)
+  }
+
+  private fun tpIndex(vararg bundles: ResolvedBundle): TargetPlatformIndex {
+    val map = HashMap<String, NavigableMap<Version, ResolvedBundle>>()
+    bundles.forEach { rb ->
+      val bsn = rb.manifest.bundleSymbolicName?.key ?: error("fixture bundle without BSN")
+      map.computeIfAbsent(bsn) { TreeMap() }[rb.manifest.bundleVersion] = rb
+    }
+    return TargetPlatformIndex(map)
+  }
+
+  private fun wsEntry(vararg headers: Pair<String, String>): List<WorkspaceBundleDescriptor> {
+    val manifest = bm(*headers)
+    val bsn = manifest.bundleSymbolicName?.key ?: error("fixture entry without BSN")
+    return listOf(WorkspaceBundleDescriptor(Paths.get("/ws/$bsn"), manifest))
+  }
+
+  @Test
+  fun `selects exporter of a package imported only by a require-bundle-closure member`() {
+    // The entry requires jupiter-api (a target bundle) which Import-Packages org.opentest4j but
+    // does not export or require it. That exporter is reachable only via the closure member's
+    // import, so it is selected only if the requirements-closure fixpoint follows the imports of
+    // selected bundles, not just the entry's own.
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.tests",
+      "Bundle-Version" to "1.0.0",
+      "Require-Bundle" to "org.junit.jupiter.api;bundle-version=\"[5.0.0,6.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.junit.jupiter.api",
+        "Bundle-SymbolicName" to "org.junit.jupiter.api",
+        "Bundle-Version" to "5.10.0",
+        "Export-Package" to "org.junit.jupiter.api",
+        "Import-Package" to "org.opentest4j"
+      ),
+      tpBundle(
+        "org.opentest4j",
+        "Bundle-SymbolicName" to "org.opentest4j",
+        "Bundle-Version" to "1.3.0",
+        "Export-Package" to "org.opentest4j"
+      )
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    assertTrue(
+      "closure member's imported exporter must be selected",
+      result.bundles.any { it.bsn == "org.opentest4j" }
+    )
+  }
+
+  @Test
+  fun `unrelated selected exporter does not mask the package's actual provider`() {
+    // org.a (selected via Require-Bundle) exports p at 1.0. org.b imports p [2.0,3.0), whose only
+    // in-range exporter is org.c. A "package already provided by the selection" shortcut would
+    // skip org.c because org.a exports p; the import must instead follow the provider that
+    // actually satisfies the range (Eclipse PDE follows the wire to the actual exporter).
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.app",
+      "Bundle-Version" to "1.0.0",
+      "Require-Bundle" to "org.a;bundle-version=\"[1.0.0,2.0.0)\", org.b;bundle-version=\"[1.0.0,2.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.a",
+        "Bundle-SymbolicName" to "org.a",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"1.0.0\""
+      ),
+      tpBundle(
+        "org.b",
+        "Bundle-SymbolicName" to "org.b",
+        "Bundle-Version" to "1.0.0",
+        "Import-Package" to "p;version=\"[2.0.0,3.0.0)\""
+      ),
+      tpBundle(
+        "org.c",
+        "Bundle-SymbolicName" to "org.c",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"2.5.0\""
+      )
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    val bsns = result.bundles.map { it.bsn }.toSet()
+    assertTrue("the in-range provider must be selected despite org.a exporting p", "org.c" in bsns)
+    assertTrue("org.a stays selected", "org.a" in bsns)
+    assertTrue("no unresolved import for p", result.unresolved.none { it.bsn == "p" })
+  }
+
+  @Test
+  fun `same-version exporters of one package do not shadow each other`() {
+    // org.x and org.y have the SAME bundle version and both export p, but only org.y's export
+    // version satisfies the import range. A provider map keyed by bundle version would keep only
+    // one of the two (hash-order dependent) and could lose org.y entirely.
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.app",
+      "Bundle-Version" to "1.0.0",
+      "Import-Package" to "p;version=\"[2.0.0,3.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.x",
+        "Bundle-SymbolicName" to "org.x",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"1.0.0\""
+      ),
+      tpBundle(
+        "org.y",
+        "Bundle-SymbolicName" to "org.y",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"2.0.0\""
+      )
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    assertTrue("the exporter satisfying the range must win", result.bundles.any { it.bsn == "org.y" })
+    assertTrue("no unresolved import for p", result.unresolved.none { it.bsn == "p" })
+  }
+
+  @Test
+  fun `optional imports of closure members are followed, unsatisfiable ones stay silent`() {
+    // Eclipse PDE's build closure runs with INCLUDE_OPTIONAL_DEPENDENCIES: an optional import
+    // whose provider exists lands on the classpath; an unsatisfiable optional import is skipped
+    // without recording a problem.
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.app",
+      "Bundle-Version" to "1.0.0",
+      "Require-Bundle" to "org.m;bundle-version=\"[1.0.0,2.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.m",
+        "Bundle-SymbolicName" to "org.m",
+        "Bundle-Version" to "1.0.0",
+        "Import-Package" to
+          "p;version=\"[1.0.0,2.0.0)\";resolution:=optional, q;version=\"[1.0.0,2.0.0)\";resolution:=optional"
+      ),
+      tpBundle(
+        "org.p.provider",
+        "Bundle-SymbolicName" to "org.p.provider",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"1.5.0\""
+      )
+      // q has no provider anywhere.
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    assertTrue("satisfiable optional import is followed", result.bundles.any { it.bsn == "org.p.provider" })
+    assertTrue("unsatisfiable optional import records no problem", result.unresolved.none { it.bsn == "q" })
+  }
+
+  @Test
+  fun `import-added bundles bring their own require-bundle closure`() {
+    // org.c enters the selection as an Import-Package provider; its Require-Bundle dependency
+    // org.d must be expanded too (fixpoint over requires, not only imports).
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.app",
+      "Bundle-Version" to "1.0.0",
+      "Import-Package" to "p;version=\"[1.0.0,2.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.c",
+        "Bundle-SymbolicName" to "org.c",
+        "Bundle-Version" to "1.0.0",
+        "Export-Package" to "p;version=\"1.0.0\"",
+        "Require-Bundle" to "org.d;bundle-version=\"[1.0.0,2.0.0)\""
+      ),
+      tpBundle(
+        "org.d",
+        "Bundle-SymbolicName" to "org.d",
+        "Bundle-Version" to "1.0.0"
+      )
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    val bsns = result.bundles.map { it.bsn }.toSet()
+    assertTrue("provider itself selected", "org.c" in bsns)
+    assertTrue("provider's required bundle selected", "org.d" in bsns)
+  }
+
+  @Test
+  fun `a fragment selected as provider pulls its host`() {
+    // org.frag exports p but is a fragment of org.host; without the host its classes cannot be
+    // loaded, so the host must join the selection (fixpoint over Fragment-Host).
+    val workspace = wsEntry(
+      "Bundle-SymbolicName" to "org.example.app",
+      "Bundle-Version" to "1.0.0",
+      "Import-Package" to "p;version=\"[1.0.0,2.0.0)\""
+    )
+    val tp = tpIndex(
+      tpBundle(
+        "org.frag",
+        "Bundle-SymbolicName" to "org.frag",
+        "Bundle-Version" to "1.0.0",
+        "Fragment-Host" to "org.host;bundle-version=\"[1.0.0,2.0.0)\"",
+        "Export-Package" to "p;version=\"1.0.0\""
+      ),
+      tpBundle(
+        "org.host",
+        "Bundle-SymbolicName" to "org.host",
+        "Bundle-Version" to "1.0.0"
+      )
+    )
+
+    val result = Resolver.resolve(tp, workspace, workspace.first(), ResolveOptions())
+    val bsns = result.bundles.map { it.bsn }.toSet()
+    assertTrue("fragment provider selected", "org.frag" in bsns)
+    assertTrue("fragment's host selected", "org.host" in bsns)
+  }
+}

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverVersionSkewTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverVersionSkewTest.kt
@@ -1,0 +1,65 @@
+package cn.varsa.pde.resolver.algo
+
+import cn.varsa.pde.resolver.index.ResolvedBundle
+import cn.varsa.pde.resolver.index.TargetPlatformIndex
+import cn.varsa.pde.resolver.manifest.BundleManifest
+import org.junit.Assert.*
+import org.junit.Test
+import org.osgi.framework.Version
+import java.nio.file.Paths
+import java.util.*
+
+class ResolverVersionSkewTest {
+
+  private fun navOf(
+    vararg pairs: Pair<String, Pair<String, ResolvedBundle>>
+  ): Map<String, NavigableMap<Version, ResolvedBundle>> {
+    val map = HashMap<String, NavigableMap<Version, ResolvedBundle>>()
+    pairs.forEach { (bsn, pv) ->
+      val (verText, rb) = pv
+      map.computeIfAbsent(bsn) { TreeMap() }[Version.parseVersion(verText)] = rb
+    }
+    return map
+  }
+
+  @Test
+  fun `entry's own require-bundle range wins over a wider transitive range`() {
+    // Version skew: the entry requires com.foo [1.0,2.0), while a closure member (mid) requires
+    // com.foo [2.0,3.0). The target ships both 1.0 and 2.0. Phase-1 pre-selection must lock the
+    // entry's own 1.0 before mid's closure would otherwise pull the higher 2.0. `mid` is declared
+    // first so a single-phase closure would expose the bug (select 2.0 before 1.0 is seen).
+    val wsManifest = BundleManifest.parse(
+      mapOf(
+        "Bundle-SymbolicName" to "org.example.app",
+        "Bundle-Version" to "1.0.0",
+        "Require-Bundle" to
+          "org.example.mid;bundle-version=\"[1.0.0,2.0.0)\", com.foo;bundle-version=\"[1.0.0,2.0.0)\""
+      )
+    )
+    val workspace = listOf(WorkspaceBundleDescriptor(Paths.get("/ws/org.example.app"), wsManifest))
+
+    val midManifest = BundleManifest.parse(
+      mapOf(
+        "Bundle-SymbolicName" to "org.example.mid",
+        "Bundle-Version" to "1.0.0",
+        "Require-Bundle" to "com.foo;bundle-version=\"[2.0.0,3.0.0)\""
+      )
+    )
+    val foo1 = BundleManifest.parse(mapOf("Bundle-SymbolicName" to "com.foo", "Bundle-Version" to "1.0.0"))
+    val foo2 = BundleManifest.parse(mapOf("Bundle-SymbolicName" to "com.foo", "Bundle-Version" to "2.0.0"))
+    val midRb = ResolvedBundle(Paths.get("/tp/plugins/org.example.mid"), midManifest, true)
+    val foo1Rb = ResolvedBundle(Paths.get("/tp/plugins/com.foo_1"), foo1, true)
+    val foo2Rb = ResolvedBundle(Paths.get("/tp/plugins/com.foo_2"), foo2, true)
+    val tpIndex = TargetPlatformIndex(
+      navOf(
+        "org.example.mid" to ("1.0.0" to midRb),
+        "com.foo" to ("1.0.0" to foo1Rb),
+        "com.foo" to ("2.0.0" to foo2Rb)
+      )
+    )
+
+    val result = Resolver.resolve(tpIndex, workspace, workspace.first(), ResolveOptions())
+    val foo = result.bundles.first { it.bsn == "com.foo" }
+    assertEquals("entry's own [1.0,2.0) must win", Version.parseVersion("1.0.0"), foo.version)
+  }
+}

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
@@ -172,4 +172,52 @@ class CompileServiceTest {
 
     assertEquals(listOf("org.example.b", "org.example.a"), specs.filter { it.isWorkspace }.map { it.bsn })
   }
+
+  @Test
+  fun `workspace bundle uses its own per-entry classpath, not the multi-version union`() {
+    // Aggregate selection carries BOTH library versions (as it does when one bundle requires lib 1.0
+    // and another 2.0). org.example.a's own closure only has 1.0, so its compile spec must not see
+    // 2.0 -- otherwise ecj could bind a 2.0-only overload it won't have at runtime.
+    val aPath = Paths.get("/workspace/org.example.a")
+    val lib1 = Paths.get("/tp/lib-1.0.0.jar")
+    val lib2 = Paths.get("/tp/lib-2.0.0.jar")
+    val aDesc = WorkspaceBundleDescriptor(
+      path = aPath,
+      manifest = dummyManifest("org.example.a", "1.0.0"),
+      classPathEntries = listOf(aPath)
+    )
+    val selected = listOf(
+      ResolvedBundle(
+        bsn = "org.example.a", version = Version.parseVersion("1.0.0"), path = aPath,
+        origin = cn.varsa.pde.resolver.algo.BundleOrigin.WORKSPACE, classPathEntries = listOf(aPath)
+      ),
+      ResolvedBundle(
+        bsn = "com.lib", version = Version.parseVersion("1.0.0"), path = lib1,
+        origin = cn.varsa.pde.resolver.algo.BundleOrigin.TARGET, classPathEntries = listOf(lib1)
+      ),
+      ResolvedBundle(
+        bsn = "com.lib", version = Version.parseVersion("2.0.0"), path = lib2,
+        origin = cn.varsa.pde.resolver.algo.BundleOrigin.TARGET, classPathEntries = listOf(lib2)
+      )
+    )
+    val plan = LaunchPlanner.PlanResult(
+      plan = LauncherPlan(emptyList(), null, emptyMap()),
+      context = LaunchContext(emptyMap(), emptyMap()),
+      selectedBundles = selected,
+      workspaceDependencies = emptyMap()
+    )
+    val lib1Cp = lib1.toAbsolutePath().normalize().toString()
+    val lib2Cp = lib2.toAbsolutePath().normalize().toString()
+    val perEntry = mapOf(
+      "org.example.a" to listOf(aPath.toAbsolutePath().normalize().toString(), lib1Cp)
+    )
+
+    val spec = CompileService.buildSpecs(plan, listOf(aDesc), perEntry).specs.single { it.bsn == "org.example.a" }
+    assertTrue(spec.classpath.contains(lib1Cp), "own version (lib 1.0) on classpath")
+    assertTrue(!spec.classpath.contains(lib2Cp), "foreign version (lib 2.0) NOT on classpath")
+
+    // Without a per-entry classpath the union (both versions) leaks in -- the prior behavior.
+    val unionSpec = CompileService.buildSpecs(plan, listOf(aDesc)).specs.single { it.bsn == "org.example.a" }
+    assertTrue(unionSpec.classpath.contains(lib2Cp), "fallback union contains both versions")
+  }
 }

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/launch/LaunchPlannerTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/launch/LaunchPlannerTest.kt
@@ -10,6 +10,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.osgi.framework.Constants.ACTIVATION_LAZY
+import org.osgi.framework.Constants.BUNDLE_ACTIVATIONPOLICY
 import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
 import org.osgi.framework.Constants.BUNDLE_VERSION
 import org.osgi.framework.Constants.REQUIRE_BUNDLE
@@ -106,5 +108,31 @@ class LaunchPlannerTest {
 
     val launchProblems = result.problemsByScope["Launch Plan"] ?: error("expected launch plan problems")
     assertTrue(launchProblems.any { it.symbol == "missing.bundle" && it.type == ResolveProblemType.MISSING_BUNDLE })
+  }
+
+  @Test
+  fun lazyActivationBundlesAreArmedEvenWhenAutoStartDefaultIsFalse() {
+    // A Bundle-ActivationPolicy: lazy bundle (e.g. org.knime.core) must be started/armed or Equinox
+    // never runs its activator + DS components — which is why `pde test` found 0 tests for the
+    // org.knime.core.workflow.tests fragment. autoStartDefault=false mirrors pde's real launch.
+    val lazyDep = resolved("lazy.dep", "1.0.0", BUNDLE_ACTIVATIONPOLICY to ACTIVATION_LAZY)
+    val eagerDep = resolved("eager.dep", "1.0.0")
+    val targetIndex = tpIndex(lazyDep, eagerDep)
+    val workspace = workspace(
+      bsn = "app.bundle",
+      version = "1.0.0",
+      REQUIRE_BUNDLE to "lazy.dep,eager.dep"
+    )
+    val environment = LaunchEnvironment(
+      targetIndex = targetIndex,
+      workspaceEntries = listOf(workspace),
+      resolverOptions = ResolveOptions(preferWorkspace = true)
+    )
+    val options = LauncherOptions(frameworkBSN = "eager.dep", defaultStartLevel = 4, autoStartDefault = false)
+    val result = LaunchPlanner.build(environment, options)
+    val bundles = result.plan.bundles.associateBy { it.bsn }
+
+    assertTrue("lazy bundle is armed so its activator/DS components run", bundles.getValue("lazy.dep").autoStart)
+    assertFalse("non-lazy bundle stays un-started under autoStartDefault=false", bundles.getValue("eager.dep").autoStart)
   }
 }


### PR DESCRIPTION
## Resolver and launch fixes: indirect imports, target config knobs, lazy activation, fragment tests

Four related fixes to the resolver and launch assembly. They share `Resolver.kt`, `Main.kt`, and `LaunchConfig.kt` and were developed together, so they're grouped into one PR.

### Resolver: indirectly-required `Import-Package`
The resolver only resolved `Import-Package` for the entry bundle and a fragment's host, never for bundles pulled in transitively via `Require-Bundle`. A dependency reachable only through such a bundle's import (e.g. `junit-jupiter-api` needing `org.opentest4j`) was left off the compile classpath and surfaced as `... cannot be resolved`. This adds a transitive `Import-Package` fixpoint closure, skipping JRE/system packages (`java.*`, `javax.*`, `jdk.*`, ...) that come from the system bundle rather than a target bundle.

### Target config: `extraBundles` and `pinnedVersions`
Two optional `target:` knobs:
- `extraBundles`: force bundles onto the classpath regardless of resolution. Not deduplicated by symbolic name, so `bsn@v1` and `bsn@v2` can coexist (OSGi allows several versions of a non-singleton bundle). A bare `bsn` uses the pinned-or-highest version; `bsn@version` is resolved exactly.
- `pinnedVersions`: a symbolic-name to exact-version map, used instead of the highest in range when the target ships the same bundle at several versions.

### Launch: honor `Bundle-ActivationPolicy: lazy`
Launch assembly ignored lazy activation, so a lazily-activated host was never armed and its activator and DS components never ran. That is harmless under a product launch, but it leaves the runtime down for headless `pde test`. Lazy bundles are now auto-started, scoped to the workspace resolution closure (arming the whole target instead causes an activation storm).

### `pde test`: fragment test plugins
The PDE JUnit runner calls `bundle.loadClass(testClass)`, which throws "Can not load a class from a fragment bundle" when `-testpluginname` names a fragment. It is now rewritten to the fragment's host, whose classloader can load the fragment's classes. Together with the lazy-activation fix, this lets `pde test` run a `*.tests` fragment of a lazily-activated host.

### Tests
Adds `ResolverIndirectImportTest` (closure, optional-import skipping, version selection, `extraBundles`/`pinnedVersions`, JRE-package skipping) and `LaunchPlannerTest` (lazy arming).