### PR TITLE
Handle CRaC checkpoint exit code (#109)

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -78,6 +78,8 @@ import org.osgi.framework.Version
 
 internal const val PDE_JUNIT_PLUGIN_TEST_APPLICATION = "org.eclipse.pde.junit.runtime.coretestapplication"
 internal const val PDE_API_ANALYZER_APPLICATION = "org.eclipse.pde.api.tools.apiAnalyzer"
+private const val CRAC_CHECKPOINT_EXIT_CODE = 137
+private const val CRAC_CHECKPOINT_ARG_PREFIX = "-XX:CRaCCheckpointTo="
 internal const val KNIME_API_ANALYZER_APPLICATION = "com.knime.enterprise.devops.eclipse.ApiAnalyzer"
 internal const val API_ANALYZER_BASELINE_PROFILE_ID = "api-analyzer-baseline"
 internal const val P2_METADATA_MIRROR_APPLICATION = "org.eclipse.equinox.p2.metadata.repository.mirrorApplication"
@@ -1185,7 +1187,37 @@ private fun executeLaunch(
   }
   val exit = process.waitFor()
   outputThread?.join()
+  if (isSuccessfulCracCheckpointExit(exit, prepared.command, prepared.layout.workDir)) {
+    logger.info("Checkpoint completed; launcher exited with CRaC checkpoint code $exit")
+    return
+  }
   if (exit != 0) error("Launcher exited with code $exit")
+}
+
+private fun isSuccessfulCracCheckpointExit(exit: Int, command: List<String>, workDir: Path): Boolean {
+  if (exit != CRAC_CHECKPOINT_EXIT_CODE) return false
+  val checkpointDir = cracCheckpointDirectory(command, workDir) ?: return false
+  return hasCheckpointImageFiles(checkpointDir)
+}
+
+private fun cracCheckpointDirectory(command: List<String>, workDir: Path): Path? {
+  for (index in command.indices) {
+    val rawPath = when {
+      command[index].startsWith(CRAC_CHECKPOINT_ARG_PREFIX) -> command[index].removePrefix(CRAC_CHECKPOINT_ARG_PREFIX)
+      command[index] == "-XX:CRaCCheckpointTo" -> command.getOrNull(index + 1)
+      else -> null
+    }?.takeIf { it.isNotBlank() } ?: continue
+    val path = Paths.get(rawPath)
+    return if (path.isAbsolute) path.normalize() else workDir.resolve(path).normalize()
+  }
+  return null
+}
+
+private fun hasCheckpointImageFiles(checkpointDir: Path): Boolean {
+  if (!Files.isDirectory(checkpointDir)) return false
+  return Files.newDirectoryStream(checkpointDir).use { entries ->
+    entries.iterator().hasNext()
+  }
 }
 
 private fun writePdeTargetPreferences(layout: LaunchLayout, targetDefinition: Path) {

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/LaunchCliTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/LaunchCliTest.kt
@@ -86,6 +86,56 @@ class LaunchCliTest {
     assertEquals(javaHome.toAbsolutePath().toString(), capturedJavaHome.readText().trim())
   }
 
+  @Test
+  fun cracCheckpointExitCodeSucceedsWhenImageFilesExist() {
+    val root = tmp.root.toPath()
+    val workspace = tmp.newFolder("workspace").also {
+      createBundle(it, "org.example.app", "1.0.0", require = "org.eclipse.osgi")
+    }
+    setupLaunchProfile(root)
+    val checkpointDir = root.resolve("checkpoint")
+    val javaHome = writeFakeJava(
+      root,
+      """
+        #!/bin/sh
+        mkdir -p '${checkpointDir.toAbsolutePath()}'
+        : > '${checkpointDir.toAbsolutePath()}/core.img'
+        : > '${checkpointDir.toAbsolutePath()}/engine'
+        exit 137
+      """.trimIndent()
+    )
+    val configFile = writeLaunchConfig(root, workspace.toPath(), javaHome, checkpointDir)
+
+    launchMain(arrayOf("--config", configFile.toString()))
+  }
+
+  @Test
+  fun cracCheckpointExitCodeFailsWhenImageFilesAreMissing() {
+    val root = tmp.root.toPath()
+    val workspace = tmp.newFolder("workspace").also {
+      createBundle(it, "org.example.app", "1.0.0", require = "org.eclipse.osgi")
+    }
+    setupLaunchProfile(root)
+    val checkpointDir = root.resolve("checkpoint")
+    val javaHome = writeFakeJava(
+      root,
+      """
+        #!/bin/sh
+        exit 137
+      """.trimIndent()
+    )
+    val configFile = writeLaunchConfig(root, workspace.toPath(), javaHome, checkpointDir)
+
+    val thrown = try {
+      launchMain(arrayOf("--config", configFile.toString()))
+      null
+    } catch (ex: IllegalStateException) {
+      ex
+    }
+
+    assertEquals("Launcher exited with code 137", thrown?.message)
+  }
+
   private fun createBundle(root: File, bsn: String, version: String, require: String? = null) {
     val metaInf = File(root, "META-INF")
     metaInf.mkdirs()
@@ -108,6 +158,42 @@ class LaunchCliTest {
       mainAttributes.putValue("Bundle-Version", version)
     }
     JarOutputStream(Files.newOutputStream(pluginsDir.resolve("${bsn}_$version.jar")), mf).use { /* empty */ }
+  }
+
+  private fun setupLaunchProfile(root: Path) {
+    createProfileWithFramework(root)
+    createBundleJar(root.resolve("target/p2/bundle-pool/plugins"), "org.eclipse.equinox.launcher", "1.0.0")
+    writeProfile(root, listOf("org.eclipse.osgi" to "1.0.0", "org.eclipse.equinox.launcher" to "1.0.0"))
+  }
+
+  private fun writeFakeJava(root: Path, script: String): Path {
+    val javaHome = root.resolve("fake-java-home")
+    val javaBinDir = javaHome.resolve("bin").createDirectories()
+    val javaExecutable = javaBinDir.resolve("java")
+    javaExecutable.writeText(script)
+    assertTrue(javaExecutable.toFile().setExecutable(true))
+    return javaHome
+  }
+
+  private fun writeLaunchConfig(root: Path, workspace: Path, javaHome: Path, checkpointDir: Path): Path {
+    root.resolve(".env").writeText("JAVA_HOME=${javaHome.toAbsolutePath()}\n")
+    val configFile = root.resolve("pde.yaml")
+    configFile.writeText(
+      """
+        target:
+          profileId: profile
+          p2Path: target/p2
+        bundles:
+          - path: ${workspace.toAbsolutePath()}
+        launches:
+          - name: run
+            application: org.example.app
+            envFile: .env
+            vmArgs:
+              - -XX:CRaCCheckpointTo=${checkpointDir.toAbsolutePath()}
+      """.trimIndent()
+    )
+    return configFile
   }
 
   private fun writeProfile(root: Path, bundles: List<Pair<String, String>>) {


### PR DESCRIPTION
Addresses #109.

## Summary
- Treat exit code 137 as a successful CRaC checkpoint only when the launch command includes `-XX:CRaCCheckpointTo` and the checkpoint directory contains generated files.
- Keep non-CRaC and incomplete checkpoint exits on the existing launcher failure path.
- Add launch CLI coverage with a fake Java executable for successful and failed checkpoint exits.

## Tests
- `./gradlew :pde-launch-engine:test --tests cn.varsa.pde.resolver.cli.LaunchCliTest`
- `./gradlew :pde-launch-engine:test`