### PR TITLE
Warn on duplicate YAML keys (#112)

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.logging.Logger
 import kotlin.io.path.inputStream
 
 data class LaunchConfig(
@@ -98,6 +99,7 @@ data class LaunchConfigContext(
 )
 
 object LaunchConfigLoader {
+  private val logger: Logger = Logger.getLogger(LaunchConfigLoader::class.java.name)
   private val mapper = ObjectMapper(YAMLFactory())
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .registerModule(KotlinModule.Builder().build())
@@ -123,6 +125,7 @@ object LaunchConfigLoader {
   private fun loadMergedNode(path: Path, visited: MutableSet<Path>): ObjectNode {
     val normalized = path.toAbsolutePath().normalize()
     require(visited.add(normalized)) { "Include cycle detected at ${normalized.toAbsolutePath()}" }
+    warnDuplicateKeys(normalized)
     val node = normalized.inputStream().use { mapper.readTree(it) }
     val objectNode = node as? ObjectNode ?: mapper.nodeFactory.objectNode()
     val baseDir = normalized.parent ?: normalized
@@ -136,6 +139,28 @@ object LaunchConfigLoader {
     merged.remove("includes")
     visited.remove(normalized)
     return merged
+  }
+
+  private fun warnDuplicateKeys(path: Path) {
+    val stack = ArrayDeque<MutableSet<String>>()
+    path.inputStream().use { input ->
+      mapper.factory.createParser(input).use { parser ->
+        while (parser.nextToken() != null) {
+          when (parser.currentToken()) {
+            com.fasterxml.jackson.core.JsonToken.START_OBJECT -> stack.addLast(mutableSetOf())
+            com.fasterxml.jackson.core.JsonToken.END_OBJECT -> if (stack.isNotEmpty()) stack.removeLast()
+            com.fasterxml.jackson.core.JsonToken.FIELD_NAME -> {
+              val key = parser.currentName()
+              val keys = stack.lastOrNull()
+              if (key != null && keys != null && !keys.add(key)) {
+                logger.warning("Duplicate YAML key '$key' in ${path.toAbsolutePath().normalize()}; the later value will override the earlier one.")
+              }
+            }
+            else -> Unit
+          }
+        }
+      }
+    }
   }
 
   private fun parseIncludes(node: ObjectNode, baseDir: Path): List<Path> {

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/LaunchConfigLoaderTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/LaunchConfigLoaderTest.kt
@@ -5,8 +5,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class LaunchConfigLoaderTest {
   @Rule @JvmField val tmp = TemporaryFolder()
@@ -292,6 +297,49 @@ class LaunchConfigLoaderTest {
 
     assertFailsWith<IllegalStateException> {
       LaunchConfigLoader.load(configFile.toPath(), root)
+    }
+  }
+
+  @Test
+  fun warnsOnDuplicateYamlKeys() {
+    val root: Path = tmp.root.toPath()
+    val configFile = root.resolve("pde.yaml").toFile()
+    configFile.writeText(
+      """
+      target:
+        definition: first.target
+        definition: second.target
+      """.trimIndent()
+    )
+    val logger = Logger.getLogger(LaunchConfigLoader::class.java.name)
+    val messages = mutableListOf<String>()
+    val handler = object : Handler() {
+      override fun publish(record: LogRecord) {
+        messages.add(record.message)
+      }
+
+      override fun flush() = Unit
+
+      override fun close() = Unit
+    }
+    val previousLevel = logger.level
+    val previousUseParent = logger.useParentHandlers
+    logger.level = Level.WARNING
+    logger.useParentHandlers = false
+    logger.addHandler(handler)
+
+    try {
+      val loaded = LaunchConfigLoader.load(configFile.toPath(), root)
+
+      assertEquals("second.target", loaded.config.target?.definition)
+      assertTrue(
+        messages.any { it.contains("Duplicate YAML key 'definition'") && it.contains("pde.yaml") },
+        "Expected duplicate key warning, got: $messages"
+      )
+    } finally {
+      logger.removeHandler(handler)
+      logger.level = previousLevel
+      logger.useParentHandlers = previousUseParent
     }
   }
 }


### PR DESCRIPTION
## Summary
- warn when a YAML object contains duplicate keys while loading launch config files
- keep existing parse/merge behavior so later duplicate values still win
- cover the warning and resulting value in `LaunchConfigLoaderTest`

Fixes #112

## Tests
- `./gradlew :pde-launch-engine:test --tests cn.varsa.pde.resolver.cli.LaunchConfigLoaderTest`
- `./gradlew :pde-launch-engine:test`