### PR TITLE
Add validate-config command

### DIFF
--- a/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
+++ b/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
@@ -172,6 +172,10 @@ private val apiFiltersAddFromReportOptions = listOf(
   CliOption(listOf("--allow-empty-selection"), "Return success when selection yields no problems")
 )
 
+private val validateConfigPositionals = listOf(
+  CliPositionalArg(0, "file", "YAML config file to validate", "1")
+)
+
 internal val pdeCommand = CliCommandGroup(
   name = "pde",
   description = "PDE tooling CLI",
@@ -332,6 +336,13 @@ internal val pdeCommand = CliCommandGroup(
           positionalArgs = apiFiltersAddFromReportPositionals
         )
       )
+    ),
+    CliCommandLeaf(
+      name = "validate-config",
+      description = "Validate a pde YAML config against the schema",
+      handler = { args -> ValidateConfigCommand.main(args) },
+      mixinStandardHelpOptions = true,
+      positionalArgs = validateConfigPositionals
     ),
     CliCommandLeaf(
       name = "schema",

--- a/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/ValidateConfigCommand.kt
+++ b/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/ValidateConfigCommand.kt
@@ -1,0 +1,30 @@
+package cn.varsa.pde.launch
+
+import cn.varsa.pde.resolver.cli.config.LaunchConfigLoader
+import java.nio.file.Path
+
+internal object ValidateConfigCommand {
+  fun main(args: Array<String>): Int {
+    if (args.size != 1) {
+      System.err.println("Usage: pde validate-config <file>")
+      return 1
+    }
+
+    val path = Path.of(args[0])
+    val normalized = path.toAbsolutePath().normalize()
+    return try {
+      LaunchConfigLoader.load(path)
+      println("Config is valid: $normalized")
+      0
+    } catch (ex: Exception) {
+      System.err.println(formatError(normalized, ex))
+      1
+    }
+  }
+
+  private fun formatError(path: Path, ex: Exception): String {
+    val message = ex.message?.trim().orEmpty()
+    if (message.startsWith("Invalid config ")) return message
+    return "Invalid config $path:\n${message.ifBlank { ex::class.java.simpleName }}"
+  }
+}

--- a/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
+++ b/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
@@ -39,6 +39,7 @@ class PdeCliTest {
     assertTrue(output.contains("Usage:"))
     assertTrue(output.contains("run"))
     assertTrue(output.contains("target"))
+    assertTrue(output.contains("validate-config"))
     assertTrue(output.contains("schema"))
   }
 
@@ -221,6 +222,23 @@ class PdeCliTest {
     assertTrue(!output.contains("--execute"))
     assertTrue(!output.contains("--workspace"))
     assertTrue(output.contains("--full-rebuild"))
+  }
+
+  @Test
+  fun `validate config subcommand help uses command name`() {
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    try {
+      runPde(arrayOf("validate-config", "--help"))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    val output = out.toString()
+    assertTrue(output.contains("Usage: pde validate-config"))
+    assertTrue(output.contains("file"))
+    assertTrue(output.contains("YAML config file to validate"))
   }
 
   @Test

--- a/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/ValidateConfigCommandTest.kt
+++ b/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/ValidateConfigCommandTest.kt
@@ -1,0 +1,85 @@
+package cn.varsa.pde.launch
+
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ValidateConfigCommandTest {
+  @Test
+  fun `validate config succeeds for valid config`() {
+    val tempDir = Files.createTempDirectory("pde-validate-config")
+    val config = tempDir.resolve("pde.yaml")
+    Files.writeString(
+      config,
+      """
+      bundles:
+        - path: ./org.example.bundle
+      launches:
+        - name: app
+          application: org.example.app
+      """.trimIndent()
+    )
+
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    val exitCode = try {
+      runPde(arrayOf("validate-config", config.toString()))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    assertEquals(0, exitCode)
+    assertEquals("Config is valid: ${config.toAbsolutePath().normalize()}\n", out.toString())
+  }
+
+  @Test
+  fun `validate config prints schema violations for invalid config`() {
+    val tempDir = Files.createTempDirectory("pde-validate-config")
+    val config = tempDir.resolve("pde.yaml")
+    Files.writeString(
+      config,
+      """
+      bundles:
+        - classRoots: [bin]
+      launches:
+        - product: org.example.product
+      unknown: true
+      """.trimIndent()
+    )
+
+    val err = ByteArrayOutputStream()
+    val savedErr = System.err
+    System.setErr(PrintStream(err))
+    val exitCode = try {
+      runPde(arrayOf("validate-config", config.toString()))
+    } finally {
+      System.setErr(savedErr)
+    }
+
+    assertEquals(1, exitCode)
+    val output = err.toString()
+    assertTrue(output.contains("Invalid config ${config.toAbsolutePath().normalize()}:"), output)
+    assertTrue(output.contains("$.bundles[0]"), output)
+    assertTrue(output.contains("$.launches[0]"), output)
+    assertTrue(output.contains("unknown"), output)
+  }
+
+  @Test
+  fun `validate config requires one file argument`() {
+    val err = ByteArrayOutputStream()
+    val savedErr = System.err
+    System.setErr(PrintStream(err))
+    val exitCode = try {
+      runPde(arrayOf("validate-config"))
+    } finally {
+      System.setErr(savedErr)
+    }
+
+    assertEquals(1, exitCode)
+    assertEquals("Usage: pde validate-config <file>\n", err.toString())
+  }
+}


### PR DESCRIPTION
Closes #115.\n\n## Summary\n- add `pde validate-config <file>` as a top-level command\n- reuse the existing launch config schema validation path\n- print human-readable validation errors and return a non-zero exit code for invalid configs\n\n## Tests\n- `./gradlew :pde-cli:test --tests '*ValidateConfigCommandTest' --tests '*PdeCliTest'`\n- `./gradlew :pde-cli:test`