### PR TITLE
Clean up pde help output

### DIFF
--- a/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
+++ b/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
@@ -395,8 +395,6 @@ private fun pdeMcpHelpText(): String = """
       }
     }
   }
-
-  ${pdeMcpWorkflowCommand.cliMcpToolsListText()}
 """.trimIndent()
 
 internal fun runPde(args: Array<String>): Int = CliMain.run(createPdeCommandLine(), args)

--- a/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
+++ b/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
@@ -3,6 +3,7 @@ package cn.varsa.pde.launch
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class PdeCliTest {
@@ -41,6 +42,39 @@ class PdeCliTest {
     assertTrue(output.contains("target"))
     assertTrue(output.contains("validate-config"))
     assertTrue(output.contains("schema"))
+  }
+
+  @Test
+  fun `top-level help omits mcp tool details`() {
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    try {
+      runPde(arrayOf("--help"))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    val output = out.toString()
+    assertTrue(output.contains("pde mcp tools list"))
+    assertFalse(output.contains("MCP tools for pde"))
+    assertFalse(output.contains("pde_compile_workspace"))
+  }
+
+  @Test
+  fun `mcp tools list prints mcp tool details`() {
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    try {
+      runPde(arrayOf("mcp", "tools", "list"))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    val output = out.toString()
+    assertTrue(output.contains("MCP tools for pde"))
+    assertTrue(output.contains("pde_compile_workspace"))
   }
 
   @Test

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -89,6 +89,24 @@ private const val TARGET_INSTALLER_LAUNCHER_JAR = "target-installer-launcher.jar
 private const val TARGET_INSTALLER_OVERRIDE_PROPERTY = "pde.targetInstaller"
 private val jsonMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 private val logger: Logger = Logger.getLogger("pde-launch-engine")
+
+internal data class TargetInstallInputs(
+  val profileId: String,
+  val p2Path: Path,
+  val targetDefinition: Path,
+  val installRoot: Path,
+  val bundlePool: Path,
+  val installerJar: Path
+) {
+  fun installerArgs(): List<String> = buildTargetInstallerArgs(
+    profileId = profileId,
+    p2Path = p2Path,
+    targetDefinition = targetDefinition,
+    installPath = installRoot,
+    bundlePool = bundlePool
+  )
+}
+
 private fun createFormatter(useColor: Boolean) = object : Formatter() {
   override fun format(record: LogRecord): String {
     val message = formatMessage(record)
@@ -1966,9 +1984,13 @@ private fun validateTargetInstallerJar(installerJar: Path, missingMessage: Strin
   return true
 }
 
-private fun buildTargetInstallerArgs(context: LaunchConfigContext, targetDefinition: Path): List<String> {
+internal fun buildTargetInstallInputs(
+  context: LaunchConfigContext,
+  installerJar: Path,
+  targetDefinition: Path
+): TargetInstallInputs {
   val targetConfig = context.config.target
-    ?: error("Missing target config while building installer args. See docs/config-yaml.md#target.")
+    ?: error("Missing target config while building target install inputs. See docs/config-yaml.md#target.")
   val baseDir = context.baseDir
   val profileId = targetConfig.profileId?.takeUnless { it.isBlank() }
     ?: error("Missing target.profileId after schema validation")
@@ -1981,13 +2003,30 @@ private fun buildTargetInstallerArgs(context: LaunchConfigContext, targetDefinit
   val resolvedP2 = baseDir.resolve(p2Path).normalize()
   val resolvedInstall = baseDir.resolve(installPath).normalize()
   val resolvedBundlePool = baseDir.resolve(bundlePool).normalize()
-  return buildTargetInstallerArgs(
+  return TargetInstallInputs(
     profileId = profileId,
     p2Path = resolvedP2,
     targetDefinition = targetDefinition,
-    installPath = resolvedInstall,
-    bundlePool = resolvedBundlePool
+    installRoot = resolvedInstall,
+    bundlePool = resolvedBundlePool,
+    installerJar = installerJar.toAbsolutePath().normalize()
   )
+}
+
+private fun validateTargetDefinition(targetDefinition: Path, configFile: Path): Boolean {
+  if (Files.isDirectory(targetDefinition)) {
+    logger.severe("target.definition must point to a .target file, not a directory: $targetDefinition")
+    return false
+  }
+  if (!Files.exists(targetDefinition)) {
+    logger.severe("target.definition does not exist: $targetDefinition (from $configFile)")
+    return false
+  }
+  if (!targetDefinition.toString().lowercase(Locale.ROOT).endsWith(".target")) {
+    logger.severe("target.definition must point to a .target file: $targetDefinition")
+    return false
+  }
+  return true
 }
 
 private fun buildTargetInstallerArgs(
@@ -2451,9 +2490,12 @@ internal fun targetMain(
     logger.severe("Missing target.definition (or a discoverable .target) in ${issueContext.file}")
     return 2
   }
-  val installerArgs = buildTargetInstallerArgs(issueContext, targetDefinition)
+  if (!validateTargetDefinition(targetDefinition, issueContext.file)) {
+    return 2
+  }
+  val installInputs = buildTargetInstallInputs(issueContext, installerJar, targetDefinition)
   val logFile = logFileOpt?.let { Paths.get(it) }
-  val exit = runInstallerLauncher(installerJar, installerArgs, issueContext.baseDir, logFile)
+  val exit = runInstallerLauncher(installInputs.installerJar, installInputs.installerArgs(), issueContext.baseDir, logFile)
   if (exit != 0) error("Target installer exited with code $exit")
   if (copyPath) {
     val profilePath = resolveProfilePath(issueContext)

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -96,14 +96,16 @@ internal data class TargetInstallInputs(
   val targetDefinition: Path,
   val installRoot: Path,
   val bundlePool: Path,
-  val installerJar: Path
+  val installerJar: Path,
+  val includeConfigurePhase: Boolean
 ) {
   fun installerArgs(): List<String> = buildTargetInstallerArgs(
     profileId = profileId,
     p2Path = p2Path,
     targetDefinition = targetDefinition,
     installPath = installRoot,
-    bundlePool = bundlePool
+    bundlePool = bundlePool,
+    includeConfigurePhase = includeConfigurePhase
   )
 }
 
@@ -2003,13 +2005,15 @@ internal fun buildTargetInstallInputs(
   val resolvedP2 = baseDir.resolve(p2Path).normalize()
   val resolvedInstall = baseDir.resolve(installPath).normalize()
   val resolvedBundlePool = baseDir.resolve(bundlePool).normalize()
+  val targetContents = TargetFileParser.parseContents(targetDefinition)
   return TargetInstallInputs(
     profileId = profileId,
     p2Path = resolvedP2,
     targetDefinition = targetDefinition,
     installRoot = resolvedInstall,
     bundlePool = resolvedBundlePool,
-    installerJar = installerJar.toAbsolutePath().normalize()
+    installerJar = installerJar.toAbsolutePath().normalize(),
+    includeConfigurePhase = targetContents.includeConfigurePhase
   )
 }
 
@@ -2034,14 +2038,16 @@ private fun buildTargetInstallerArgs(
   p2Path: Path,
   targetDefinition: Path,
   installPath: Path,
-  bundlePool: Path
+  bundlePool: Path,
+  includeConfigurePhase: Boolean = true
 ): List<String> {
   return listOf(
     "-profileId", profileId,
     "-p2Path", p2Path.toString(),
     "-targetDefinition", targetDefinition.toString(),
     "-install-folder", installPath.toString(),
-    "-bundlePool", bundlePool.toString()
+    "-bundlePool", bundlePool.toString(),
+    "-includeConfigurePhase", includeConfigurePhase.toString()
   )
 }
 
@@ -2104,13 +2110,19 @@ private fun provisionBaselineTargetProfile(
   val baselineP2Path = baselineInstallRoot.resolve("p2")
   val baselineInstallPath = baselineInstallRoot.resolve("install")
   val baselineProfileId = API_ANALYZER_BASELINE_PROFILE_ID
+  val baselineTargetContents = runCatching { TargetFileParser.parseContents(baselineTargetDefinition) }
+    .getOrElse { error ->
+      logger.severe("Failed to parse baseline target definition $baselineTargetDefinition: ${error.message}")
+      return null
+    }
 
   val installerArgs = buildTargetInstallerArgs(
     profileId = baselineProfileId,
     p2Path = baselineP2Path,
     targetDefinition = baselineTargetDefinition,
     installPath = baselineInstallPath,
-    bundlePool = bundlePoolPath
+    bundlePool = bundlePoolPath,
+    includeConfigurePhase = baselineTargetContents.includeConfigurePhase
   )
   val exitCode = runTargetInstallerLauncher(
     installerJar = installerJar,
@@ -2493,7 +2505,11 @@ internal fun targetMain(
   if (!validateTargetDefinition(targetDefinition, issueContext.file)) {
     return 2
   }
-  val installInputs = buildTargetInstallInputs(issueContext, installerJar, targetDefinition)
+  val installInputs = runCatching { buildTargetInstallInputs(issueContext, installerJar, targetDefinition) }
+    .getOrElse { error ->
+      logger.severe("Failed to parse target.definition $targetDefinition: ${error.message}")
+      return 2
+    }
   val logFile = logFileOpt?.let { Paths.get(it) }
   val exit = runInstallerLauncher(installInputs.installerJar, installInputs.installerArgs(), issueContext.baseDir, logFile)
   if (exit != 0) error("Target installer exited with code $exit")

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/TargetFileParser.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/TargetFileParser.kt
@@ -14,7 +14,8 @@ data class TargetLaunchArgs(
 
 data class TargetDefinitionContents(
   val repositories: List<URI>,
-  val installUnits: List<InstallUnitRef>
+  val installUnits: List<InstallUnitRef>,
+  val includeConfigurePhase: Boolean
 )
 
 data class InstallUnitRef(
@@ -34,7 +35,12 @@ object TargetFileParser {
     val document = parseDocument(path)
     val repositories = extractRepositoryLocations(document)
     val units = extractInstallUnits(document)
-    return TargetDefinitionContents(repositories = repositories, installUnits = units)
+    val includeConfigurePhase = extractIncludeConfigurePhase(document)
+    return TargetDefinitionContents(
+      repositories = repositories,
+      installUnits = units,
+      includeConfigurePhase = includeConfigurePhase
+    )
   }
 
   private fun parseDocument(path: Path): Document {
@@ -85,5 +91,19 @@ object TargetFileParser {
       results += InstallUnitRef(id = id, version = version)
     }
     return results
+  }
+
+  private fun extractIncludeConfigurePhase(doc: Document): Boolean {
+    val locationNodes = doc.getElementsByTagName("location")
+    var includeConfigurePhase: Boolean? = null
+    for (index in 0 until locationNodes.length) {
+      val node = locationNodes.item(index) as? Element ?: continue
+      if (!node.getAttribute("type").equals("InstallableUnit", ignoreCase = true)) continue
+      val includeAttr = node.getAttribute("includeConfigurePhase")?.trim().orEmpty()
+      if (includeAttr.isNotBlank()) {
+        includeConfigurePhase = includeAttr.equals("true", ignoreCase = true)
+      }
+    }
+    return includeConfigurePhase ?: true
   }
 }

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
@@ -1,0 +1,135 @@
+package cn.varsa.pde.resolver.cli
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class TargetInstallInputsTest {
+  @Rule @JvmField val tmp = TemporaryFolder()
+
+  @Test
+  fun `target-install discovers target file and passes defaulted installer args`() {
+    val baseDir = tmp.newFolder("defaults").toPath()
+    val configFile = baseDir.resolve("pde.yaml")
+    Files.writeString(
+      configFile,
+      """
+        target:
+          installer: tools/target-installer-launcher.jar
+        bundles: []
+      """.trimIndent()
+    )
+    val installerJar = baseDir.resolve("tools/target-installer-launcher.jar")
+    Files.createDirectories(installerJar.parent)
+    Files.writeString(installerJar, "stub")
+    val targetDefinition = baseDir.resolve("example.target")
+    Files.writeString(targetDefinition, "<target></target>")
+
+    var invokedInstaller: Path? = null
+    var invokedArgs: List<String>? = null
+    var invokedWorkingDir: Path? = null
+
+    val exit = targetMain(
+      arrayOf("--config", configFile.toString()),
+      runInstallerLauncher = { installer, args, workingDir, _ ->
+        invokedInstaller = installer
+        invokedArgs = args
+        invokedWorkingDir = workingDir
+        0
+      }
+    )
+
+    assertEquals(0, exit)
+    assertEquals(installerJar.toAbsolutePath().normalize(), invokedInstaller)
+    assertEquals(baseDir.toAbsolutePath().normalize(), invokedWorkingDir)
+    assertEquals(
+      listOf(
+        "-profileId", "profile",
+        "-p2Path", baseDir.resolve("target/p2").normalize().toString(),
+        "-targetDefinition", targetDefinition.toAbsolutePath().normalize().toString(),
+        "-install-folder", baseDir.resolve("target/install").normalize().toString(),
+        "-bundlePool", baseDir.resolve("target/bundle-pool").normalize().toString()
+      ),
+      invokedArgs
+    )
+  }
+
+  @Test
+  fun `target-install uses explicit target file and configured path args`() {
+    val baseDir = tmp.newFolder("configured").toPath()
+    val configFile = baseDir.resolve("pde.yaml")
+    Files.writeString(
+      configFile,
+      """
+        target:
+          installer: installer.jar
+          definition: targets/selected.target
+          profileId: custom-profile
+          p2Path: .p2-state
+          install: eclipse-install
+          bundlePool: shared-pool
+        bundles: []
+      """.trimIndent()
+    )
+    val installerJar = baseDir.resolve("installer.jar")
+    Files.writeString(installerJar, "stub")
+    val selectedTarget = baseDir.resolve("targets/selected.target")
+    Files.createDirectories(selectedTarget.parent)
+    Files.writeString(selectedTarget, "<target></target>")
+    Files.writeString(baseDir.resolve("ignored.target"), "<target></target>")
+
+    var invokedArgs: List<String>? = null
+
+    val exit = targetMain(
+      arrayOf("--config", configFile.toString()),
+      runInstallerLauncher = { _, args, _, _ ->
+        invokedArgs = args
+        0
+      }
+    )
+
+    assertEquals(0, exit)
+    assertEquals(
+      listOf(
+        "-profileId", "custom-profile",
+        "-p2Path", baseDir.resolve(".p2-state").normalize().toString(),
+        "-targetDefinition", selectedTarget.normalize().toString(),
+        "-install-folder", baseDir.resolve("eclipse-install").normalize().toString(),
+        "-bundlePool", baseDir.resolve("shared-pool").normalize().toString()
+      ),
+      invokedArgs
+    )
+  }
+
+  @Test
+  fun `target-install rejects missing explicit target file before launching installer`() {
+    val baseDir = tmp.newFolder("missing-target").toPath()
+    val configFile = baseDir.resolve("pde.yaml")
+    Files.writeString(
+      configFile,
+      """
+        target:
+          installer: installer.jar
+          definition: missing.target
+        bundles: []
+      """.trimIndent()
+    )
+    Files.writeString(baseDir.resolve("installer.jar"), "stub")
+
+    var launched = false
+    val exit = targetMain(
+      arrayOf("--config", configFile.toString()),
+      runInstallerLauncher = { _, _, _, _ ->
+        launched = true
+        0
+      }
+    )
+
+    assertEquals(2, exit)
+    assertFalse(launched)
+  }
+}

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
@@ -52,7 +52,8 @@ class TargetInstallInputsTest {
         "-p2Path", baseDir.resolve("target/p2").normalize().toString(),
         "-targetDefinition", targetDefinition.toAbsolutePath().normalize().toString(),
         "-install-folder", baseDir.resolve("target/install").normalize().toString(),
-        "-bundlePool", baseDir.resolve("target/bundle-pool").normalize().toString()
+        "-bundlePool", baseDir.resolve("target/bundle-pool").normalize().toString(),
+        "-includeConfigurePhase", "true"
       ),
       invokedArgs
     )
@@ -79,7 +80,16 @@ class TargetInstallInputsTest {
     Files.writeString(installerJar, "stub")
     val selectedTarget = baseDir.resolve("targets/selected.target")
     Files.createDirectories(selectedTarget.parent)
-    Files.writeString(selectedTarget, "<target></target>")
+    Files.writeString(
+      selectedTarget,
+      """
+        <target>
+          <locations>
+            <location type="InstallableUnit" includeConfigurePhase="false"/>
+          </locations>
+        </target>
+      """.trimIndent()
+    )
     Files.writeString(baseDir.resolve("ignored.target"), "<target></target>")
 
     var invokedArgs: List<String>? = null
@@ -99,7 +109,8 @@ class TargetInstallInputsTest {
         "-p2Path", baseDir.resolve(".p2-state").normalize().toString(),
         "-targetDefinition", selectedTarget.normalize().toString(),
         "-install-folder", baseDir.resolve("eclipse-install").normalize().toString(),
-        "-bundlePool", baseDir.resolve("shared-pool").normalize().toString()
+        "-bundlePool", baseDir.resolve("shared-pool").normalize().toString(),
+        "-includeConfigurePhase", "false"
       ),
       invokedArgs
     )

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/config/TargetFileParserContentsTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/config/TargetFileParserContentsTest.kt
@@ -34,6 +34,7 @@ class TargetFileParserContentsTest {
     assertEquals(2, contents.installUnits.size)
     assertEquals(InstallUnitRef(id = "org.example.feature", version = "1.2.3"), contents.installUnits[0])
     assertEquals(InstallUnitRef(id = "org.example.bundle", version = null), contents.installUnits[1])
+    assertTrue(contents.includeConfigurePhase)
   }
 
   @Test
@@ -55,5 +56,41 @@ class TargetFileParserContentsTest {
 
     assertEquals(listOf(URI("https://example.com/updates")), contents.repositories)
     assertTrue(contents.installUnits.isEmpty())
+    assertTrue(contents.includeConfigurePhase)
+  }
+
+  @Test
+  fun parsesIncludeConfigurePhaseFromInstallableUnitLocations() {
+    val xml = """
+      <target name="example" sequenceNumber="1">
+        <locations>
+          <location type="Directory" includeConfigurePhase="false"/>
+          <location type="InstallableUnit" includeConfigurePhase="false"/>
+        </locations>
+      </target>
+    """.trimIndent()
+    val path = createTempFile(prefix = "target", suffix = ".target")
+    path.writeText(xml)
+
+    val contents = TargetFileParser.parseContents(path)
+
+    assertEquals(false, contents.includeConfigurePhase)
+  }
+
+  @Test
+  fun defaultsIncludeConfigurePhaseToTrueWhenMissing() {
+    val xml = """
+      <target name="example" sequenceNumber="1">
+        <locations>
+          <location type="InstallableUnit"/>
+        </locations>
+      </target>
+    """.trimIndent()
+    val path = createTempFile(prefix = "target", suffix = ".target")
+    path.writeText(xml)
+
+    val contents = TargetFileParser.parseContents(path)
+
+    assertTrue(contents.includeConfigurePhase)
   }
 }

--- a/docs/target-installer-boundaries.md
+++ b/docs/target-installer-boundaries.md
@@ -1,0 +1,98 @@
+# Target Installer Ownership Boundaries
+
+`pde target install` should behave as part of one `pde` product, but Eclipse p2
+provisioning still needs an Equinox/OSGi runtime. This inventory defines the
+safe boundary for moving target-installer support code into the Kotlin `pde`
+side without changing live p2 behavior.
+
+## Move Or Share In Kotlin `pde`
+
+These pieces are regular CLI/config/file-model logic and should be owned by
+`pde`:
+
+- Target-install input modeling: profile id, p2 area, target definition,
+  install root, bundle pool, installer launcher path, and generated installer
+  arguments.
+- Config defaults and validation for `target.profileId`, `target.p2Path`,
+  `target.install`, `target.bundlePool`, `target.definition`, and
+  `target.installer`.
+- Relative path resolution from the config directory.
+- Target definition discovery from the config directory when
+  `target.definition` is omitted.
+- Non-p2 `.target` metadata parsing: repository locations, installable-unit
+  references, launch program/vm arguments, and `includeConfigurePhase`.
+- Packaged launcher discovery and validation for the internal
+  `target-installer-launcher.jar` bundled with the CLI distribution.
+- Process invocation contract for the standalone launcher: Java executable,
+  `java -jar`, cache mode, argument order, working directory, stdout/stderr
+  forwarding, and error handling before the p2 runtime starts.
+- Regression tests that can run without provisioning a real target platform.
+
+## Keep Inside The Equinox Target Installer
+
+These pieces are runtime-sensitive p2/OSGi logic and should stay behind the
+standalone target-installer process boundary:
+
+- `IApplication` startup and `IApplicationContext` access.
+- `IProvisioningAgent` and `IProvisioningAgentProvider` lifecycle.
+- p2 metadata and artifact repository managers.
+- Repository loading and p2 installable-unit queries.
+- Profile creation, deletion, upsert, registry access, and bundle-pool
+  semantics.
+- `ProvisioningSession`, `InstallOperation`, `UpdateOperation`, and
+  `ProvisioningContext` setup.
+- `ProfileModificationJob` execution and progress monitors.
+- p2 planner status, conflict reporting, warning/error handling, and phase
+  selection such as skipping configure/unconfigure phases.
+- Any dependency on internal or provisional Eclipse p2 APIs.
+- OSGi service activation and logging that only exists in the Equinox runtime.
+
+## Defer To #100
+
+These decisions need a separate runtime feasibility spike and should not block
+the low-risk unification work:
+
+- Replacing the Java Equinox application with a Kotlin OSGi application.
+- Embedding Equinox/p2 services directly inside the main `pde` CLI process.
+- Changing p2 service setup, provisioning-agent ownership, or repository-manager
+  lifecycle.
+- Replacing p2 operation/progress/status handling with a different abstraction.
+- Changing release packaging for the p2 runtime beyond making the current
+  launcher an internal `pde` distribution artifact.
+
+## Current Class Ownership
+
+- `apps/pde-launch` and `core/pde-launch-engine`: own public CLI UX, YAML schema,
+  config loading, path defaults, target discovery, packaged launcher lookup,
+  process invocation, and non-p2 tests.
+- `core/pde-launch-engine/.../TargetFileParser.kt`: should be the shared parser
+  for non-p2 `.target` metadata used by target install, target mirror, launch,
+  and tests.
+- `tools/target-installer/.../ReadProperties.java`: should remain a thin
+  compatibility parser for normalized arguments emitted by Kotlin `pde`.
+- `tools/target-installer/.../TargetFileParser.java`: should be reduced or
+  removed once the standalone launcher receives all non-p2 target metadata it
+  needs from Kotlin `pde`.
+- `tools/target-installer/.../Application.java`, `Activator.java`,
+  `Repository.java`, `Operation.java`, and p2 helper methods in `Utils.java`:
+  remain inside the Equinox application.
+
+## Near-Term Implementation Rule
+
+Move the seam toward this flow while preserving behavior:
+
+```text
+pde CLI/config/schema/tests
+        |
+        v
+Kotlin target install model and .target metadata parser
+        |
+        v
+normalized launcher process invocation
+        |
+        v
+minimal Equinox application for live p2 provisioning
+```
+
+Every step should keep the last box narrow and runtime-focused, with local tests
+covering the upper three boxes without starting p2.

--- a/tools/target-installer/src/org/knime/targetinstaller/osgi/Application.java
+++ b/tools/target-installer/src/org/knime/targetinstaller/osgi/Application.java
@@ -80,7 +80,7 @@ public class Application implements IApplication{
         var operation = new InstallOperation(session, installableUnits);
         initProvisioningContext(agent, targetDefinition, operation);
 
-        new Operation(profile.getProfileId(), operation, arguments.isDryRun(), targetDefinition.includeConfigurePhase())
+        new Operation(profile.getProfileId(), operation, arguments.isDryRun(), resolvedConfig.includeConfigurePhase())
                 .resolve()
                 .ifPresent(Operation::execute);
 

--- a/tools/target-installer/src/org/knime/targetinstaller/utils/ReadProperties.java
+++ b/tools/target-installer/src/org/knime/targetinstaller/utils/ReadProperties.java
@@ -94,6 +94,11 @@ public class ReadProperties {
                     values.put("bundlePool", value);
                     i++;
                     break;
+                case "-includeConfigurePhase":
+                case "-include-configure-phase":
+                    values.put("includeConfigurePhase", value);
+                    i++;
+                    break;
                 default:
                     break;
             }
@@ -111,7 +116,8 @@ public class ReadProperties {
                 resolvePath(resolvedBase, values.get("p2Path")),
                 resolvePath(resolvedBase, values.get("targetDefinition")),
                 resolvePath(resolvedBase, values.get("installFolder")),
-                resolvePath(resolvedBase, values.get("bundlePool"))
+                resolvePath(resolvedBase, values.get("bundlePool")),
+                Boolean.parseBoolean(values.getOrDefault("includeConfigurePhase", "true"))
         ));
     }
 
@@ -127,7 +133,7 @@ public class ReadProperties {
     }
 
     public record InstallConfiguration(String profileId, Path p2Path, Path targetDefinition, Path installFolder,
-                                       Path bundlePool) {
+                                       Path bundlePool, boolean includeConfigurePhase) {
 
     }
 

--- a/tools/target-installer/src/org/knime/targetinstaller/utils/TargetFileParser.java
+++ b/tools/target-installer/src/org/knime/targetinstaller/utils/TargetFileParser.java
@@ -58,7 +58,7 @@ import java.util.List;
 
 public class TargetFileParser {
 
-    public record ParsedTargetFile(List<URI> repoURIs, List<Types.IURef> iuRefs, boolean includeConfigurePhase) {}
+    public record ParsedTargetFile(List<URI> repoURIs, List<Types.IURef> iuRefs) {}
 
 
     public record IUReference(String id, String version) {}
@@ -71,7 +71,6 @@ public class TargetFileParser {
     public static ParsedTargetFile parseTargetFile(String path) {
         List<URI> repoURIs = new ArrayList<>();
         List<Types.IURef> iuRefs = new ArrayList<>();
-        Boolean includeConfigurePhase = null;
 
         File file = (new File(path)).toPath().toAbsolutePath().toFile();
         if (!file.exists()) {
@@ -90,19 +89,6 @@ public class TargetFileParser {
             for (int i = 0; i < locationNodes.getLength(); i++) {
                 Element locationElem = (Element) locationNodes.item(i);
                 if (locationElem == null) continue;
-
-                // PDE only persists includeConfigurePhase on IU bundle containers (TargetDefinitionPersistenceHelper),
-                // and IULocationFactory reads it to set IUBundleContainer.INCLUDE_CONFIGURE_PHASE
-                // (see eclipse.pde/ui/org.eclipse.pde.core/.../IULocationFactory.java). When the attribute is absent we
-                // default to true so fully provisioned installs still run the configure phase even though PDE generally
-                // skips it for IDE launches.
-                var locationType = locationElem.getAttribute("type");
-                if ("InstallableUnit".equalsIgnoreCase(locationType)) {
-                    var includeAttr = locationElem.getAttribute("includeConfigurePhase");
-                    if (!includeAttr.isBlank()) {
-                        includeConfigurePhase = Boolean.parseBoolean(includeAttr);
-                    }
-                }
 
                 // 1) Repositories
                 NodeList repoNodes = locationElem.getElementsByTagName("repository");
@@ -141,6 +127,6 @@ public class TargetFileParser {
             throw new IllegalStateException("Failed to parse target definition " + file + ": " + e.getMessage(), e);
         }
 
-        return new ParsedTargetFile(repoURIs, iuRefs, includeConfigurePhase == null || includeConfigurePhase);
+        return new ParsedTargetFile(repoURIs, iuRefs);
     }
 }


### PR DESCRIPTION
## Summary
- Remove the expanded MCP tool listing from `pde --help`
- Keep the detailed listing available through `pde mcp tools list`
- Add CLI regression tests for both help surfaces

Fixes #124

## Tests
- `./gradlew :pde-cli:test --tests cn.varsa.pde.launch.PdeCliTest`
- `./gradlew :pde-cli:test`