### PR TITLE
Clean up pde help output

### DIFF
--- a/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
+++ b/apps/pde-launch/src/main/kotlin/cn/varsa/pde/launch/Main.kt
@@ -395,8 +395,6 @@ private fun pdeMcpHelpText(): String = """
       }
     }
   }
-
-  ${pdeMcpWorkflowCommand.cliMcpToolsListText()}
 """.trimIndent()
 
 internal fun runPde(args: Array<String>): Int = CliMain.run(createPdeCommandLine(), args)

--- a/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
+++ b/apps/pde-launch/src/test/kotlin/cn/varsa/pde/launch/PdeCliTest.kt
@@ -3,6 +3,7 @@ package cn.varsa.pde.launch
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class PdeCliTest {
@@ -41,6 +42,39 @@ class PdeCliTest {
     assertTrue(output.contains("target"))
     assertTrue(output.contains("validate-config"))
     assertTrue(output.contains("schema"))
+  }
+
+  @Test
+  fun `top-level help omits mcp tool details`() {
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    try {
+      runPde(arrayOf("--help"))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    val output = out.toString()
+    assertTrue(output.contains("pde mcp tools list"))
+    assertFalse(output.contains("MCP tools for pde"))
+    assertFalse(output.contains("pde_compile_workspace"))
+  }
+
+  @Test
+  fun `mcp tools list prints mcp tool details`() {
+    val out = ByteArrayOutputStream()
+    val savedOut = System.out
+    System.setOut(PrintStream(out))
+    try {
+      runPde(arrayOf("mcp", "tools", "list"))
+    } finally {
+      System.setOut(savedOut)
+    }
+
+    val output = out.toString()
+    assertTrue(output.contains("MCP tools for pde"))
+    assertTrue(output.contains("pde_compile_workspace"))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Remove the expanded MCP tool listing from `pde --help`
- Keep the detailed listing available through `pde mcp tools list`
- Add CLI regression tests for both help surfaces

Fixes #124

## Tests
- `./gradlew :pde-cli:test --tests cn.varsa.pde.launch.PdeCliTest`
- `./gradlew :pde-cli:test`