### PR TITLE
Add opt-in to trust all p2 authorities during `target install`

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -2012,7 +2012,8 @@ private fun runTargetInstallerLauncher(
   installerJar: Path,
   installerArgs: List<String>,
   workingDir: Path,
-  logFile: Path?
+  logFile: Path?,
+  trustAllAuthorities: Boolean = false
 ): Int {
   val javaBin = resolveJavaBin()
   val command = mutableListOf(
@@ -2026,6 +2027,11 @@ private fun runTargetInstallerLauncher(
   val processBuilder = ProcessBuilder(command)
     .directory(workingDir.toFile())
     .redirectErrorStream(true)
+  if (trustAllAuthorities) {
+    // target.trustAllAuthorities: true -> hand the installer JVM the opt-in it reads, so p2 skips the
+    // HttpClient-based authority check that fails where the NIO loopback/AF_UNIX self-pipe is blocked.
+    processBuilder.environment()["PDE_TRUST_ALL_AUTHORITIES"] = "true"
+  }
   if (logFile != null) {
     val outputLog = logFile.toAbsolutePath().normalize()
     outputLog.parent?.let { Files.createDirectories(it) }
@@ -2085,7 +2091,8 @@ private fun provisionBaselineTargetProfile(
     installerJar = installerJar,
     installerArgs = installerArgs,
     workingDir = context.baseDir,
-    logFile = logFile
+    logFile = logFile,
+    trustAllAuthorities = context.config.target.trustAllAuthorities == true
   )
   if (exitCode != 0) {
     logger.severe("Target installer exited with code $exitCode while provisioning baseline target.")
@@ -2387,7 +2394,7 @@ private fun writeOutputs(dir: Path, plan: LauncherPlan, ctx: LaunchContext, opts
 
 internal fun targetMain(
   args: Array<String>,
-  runInstallerLauncher: (installerJar: Path, installerArgs: List<String>, workingDir: Path, logFile: Path?) -> Int = ::runTargetInstallerLauncher,
+  runInstallerLauncher: (installerJar: Path, installerArgs: List<String>, workingDir: Path, logFile: Path?, trustAllAuthorities: Boolean) -> Int = ::runTargetInstallerLauncher,
   clipboardCopier: (String) -> Boolean = ::copyStringToClipboard
 ): Int {
   val normalizedArgs = normalizeArgsWithImplicitConfig(args, launchOptionsRequiringValue)
@@ -2468,7 +2475,13 @@ internal fun targetMain(
       return 2
     }
   val logFile = logFileOpt?.let { Paths.get(it) }
-  val exit = runInstallerLauncher(installInputs.installerJar, installInputs.installerArgs(), issueContext.baseDir, logFile)
+  val exit = runInstallerLauncher(
+    installInputs.installerJar,
+    installInputs.installerArgs(),
+    issueContext.baseDir,
+    logFile,
+    targetConfig.trustAllAuthorities == true
+  )
   if (exit != 0) error("Target installer exited with code $exit")
   if (copyPath) {
     val profilePath = resolveProfilePath(issueContext)

--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/config/LaunchConfig.kt
@@ -33,6 +33,7 @@ data class TargetConfig(
   val p2Repositories: List<String>? = null,
   val extraBundles: List<String>? = null,
   val pinnedVersions: Map<String, String>? = null,
+  val trustAllAuthorities: Boolean? = null,
   val mirror: TargetMirrorConfig? = null
 )
 

--- a/core/pde-launch-engine/src/main/resources/schema/pde.schema.yaml
+++ b/core/pde-launch-engine/src/main/resources/schema/pde.schema.yaml
@@ -245,6 +245,15 @@ $defs:
           the pin. For `Import-Package`, the pinned bundle version must still export the requested
           package with an export version matching the import range. Invalid version strings fail
           config validation.
+      trustAllAuthorities:
+        type: boolean
+        default: false
+        description: >-
+          Opt-in: trust all p2 authorities during `pde target install`, skipping p2's
+          HttpClient-based certificate gathering. Needed in sandboxed environments that block
+          the NIO selector's loopback/AF_UNIX self-pipe ("Unable to establish loopback
+          connection"). Disables remote authority verification — enable only for trusted or
+          local (file:) targets. Also settable via the PDE_TRUST_ALL_AUTHORITIES env var.
       mirror:
         $ref: "#/$defs/targetMirror"
         description: Mirror options used by `pde target mirror`.

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallCopyPathTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallCopyPathTest.kt
@@ -56,7 +56,7 @@ class TargetInstallCopyPathTest {
     try {
       val exit = targetMain(
         arrayOf("--config", configFile.toString(), "--copy-path", "--verbose"),
-        runInstallerLauncher = { _, _, _, _ -> 0 },
+        runInstallerLauncher = { _, _, _, _, _ -> 0 },
         clipboardCopier = {
           copiedPath = it
           true
@@ -97,7 +97,7 @@ class TargetInstallCopyPathTest {
       System.setProperty("pde.targetInstaller", packagedInstaller.toString())
       val exit = targetMain(
         arrayOf("--config", configFile.toString()),
-        runInstallerLauncher = { installerJar, _, _, _ ->
+        runInstallerLauncher = { installerJar, _, _, _, _ ->
           invokedInstaller = installerJar
           0
         }
@@ -142,7 +142,7 @@ class TargetInstallCopyPathTest {
       System.setProperty("java.class.path", appJar.toString())
       val exit = targetMain(
         arrayOf("--config", configFile.toString()),
-        runInstallerLauncher = { installerJar, _, _, _ ->
+        runInstallerLauncher = { installerJar, _, _, _, _ ->
           invokedInstaller = installerJar
           0
         }

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/TargetInstallInputsTest.kt
@@ -32,13 +32,15 @@ class TargetInstallInputsTest {
     var invokedInstaller: Path? = null
     var invokedArgs: List<String>? = null
     var invokedWorkingDir: Path? = null
+    var invokedTrustAllAuthorities = true
 
     val exit = targetMain(
       arrayOf("--config", configFile.toString()),
-      runInstallerLauncher = { installer, args, workingDir, _ ->
+      runInstallerLauncher = { installer, args, workingDir, _, trustAllAuthorities ->
         invokedInstaller = installer
         invokedArgs = args
         invokedWorkingDir = workingDir
+        invokedTrustAllAuthorities = trustAllAuthorities
         0
       }
     )
@@ -46,6 +48,7 @@ class TargetInstallInputsTest {
     assertEquals(0, exit)
     assertEquals(installerJar.toAbsolutePath().normalize(), invokedInstaller)
     assertEquals(baseDir.toAbsolutePath().normalize(), invokedWorkingDir)
+    assertFalse(invokedTrustAllAuthorities)
     assertEquals(
       listOf(
         "-profileId", "profile",
@@ -73,6 +76,7 @@ class TargetInstallInputsTest {
           p2Path: .p2-state
           install: eclipse-install
           bundlePool: shared-pool
+          trustAllAuthorities: true
         bundles: []
       """.trimIndent()
     )
@@ -93,16 +97,19 @@ class TargetInstallInputsTest {
     Files.writeString(baseDir.resolve("ignored.target"), "<target></target>")
 
     var invokedArgs: List<String>? = null
+    var invokedTrustAllAuthorities = false
 
     val exit = targetMain(
       arrayOf("--config", configFile.toString()),
-      runInstallerLauncher = { _, args, _, _ ->
+      runInstallerLauncher = { _, args, _, _, trustAllAuthorities ->
         invokedArgs = args
+        invokedTrustAllAuthorities = trustAllAuthorities
         0
       }
     )
 
     assertEquals(0, exit)
+    assertEquals(true, invokedTrustAllAuthorities)
     assertEquals(
       listOf(
         "-profileId", "custom-profile",
@@ -134,7 +141,7 @@ class TargetInstallInputsTest {
     var launched = false
     val exit = targetMain(
       arrayOf("--config", configFile.toString()),
-      runInstallerLauncher = { _, _, _, _ ->
+      runInstallerLauncher = { _, _, _, _, _ ->
         launched = true
         0
       }
@@ -163,7 +170,7 @@ class TargetInstallInputsTest {
     var launched = false
     val exit = targetMain(
       arrayOf("--config", configFile.toString()),
-      runInstallerLauncher = { _, _, _, _ ->
+      runInstallerLauncher = { _, _, _, _, _ ->
         launched = true
         0
       }

--- a/tools/target-installer/src/org/knime/targetinstaller/osgi/Application.java
+++ b/tools/target-installer/src/org/knime/targetinstaller/osgi/Application.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import static org.knime.targetinstaller.utils.Utils.createDirIfNotExist;
 import static org.knime.targetinstaller.utils.Utils.deleteProfileIfExists;
 import static org.knime.targetinstaller.utils.Utils.patchTrustedAuthorities;
+import static org.knime.targetinstaller.utils.Utils.trustAllAuthoritiesIfOptedIn;
 import static org.knime.targetinstaller.utils.Utils.printProfileSummary;
 import static org.knime.targetinstaller.utils.Utils.upsertProfile;
 
@@ -66,6 +67,9 @@ public class Application implements IApplication{
         // this property skips the entire method
         System.setProperty("eclipse.p2.unsignedPolicy", "allow");
         patchTrustedAuthorities(agent, profile);
+        // Opt-in (PDE_TRUST_ALL_AUTHORITIES=true): skip AuthorityChecker's HttpClient-based certificate
+        // gathering, which fails in sandboxes that block the NIO selector's loopback/AF_UNIX self-pipe.
+        trustAllAuthoritiesIfOptedIn(agent, profile);
 
         var repository = new Repository(agent);
         repository.load(targetDefinition.repoURIs());

--- a/tools/target-installer/src/org/knime/targetinstaller/utils/Utils.java
+++ b/tools/target-installer/src/org/knime/targetinstaller/utils/Utils.java
@@ -86,6 +86,45 @@ public class Utils {
         authChecker.persistTrustedAuthorities(trustedAuths);  // not sure why this is an instance method
     }
 
+    /**
+     * Name of the opt-in environment variable (also honoured as the {@code pde.trustAllAuthorities}
+     * system property) that, when truthy, makes the installer trust all p2 authorities.
+     */
+    public static final String TRUST_ALL_AUTHORITIES_ENV = "PDE_TRUST_ALL_AUTHORITIES";
+
+    /** @return {@code true} if trust-all was opted into via env var or system property. */
+    public static boolean trustAllAuthoritiesOptedIn() {
+        var value = System.getenv(TRUST_ALL_AUTHORITIES_ENV);
+        if (value == null) {
+            value = System.getProperty("pde.trustAllAuthorities");
+        }
+        return value != null
+                && ("true".equalsIgnoreCase(value) || "1".equals(value) || "yes".equalsIgnoreCase(value));
+    }
+
+    /**
+     * Opt-in escape hatch: trust all p2 authorities so {@link AuthorityChecker#start} returns before it
+     * builds a {@link java.net.http.HttpClient}. That client opens an NIO selector whose self-pipe needs a
+     * loopback / AF_UNIX socket; in sandboxed environments that connection is blocked and provisioning dies
+     * in the Collect phase with "Unable to establish loopback connection". Trusting all authorities skips the
+     * certificate gathering entirely.
+     * <p>
+     * Off by default and intentionally so: it disables remote authority verification. Enable only for trusted
+     * or local ({@code file:}) targets, via {@code PDE_TRUST_ALL_AUTHORITIES=true}. A normally-reachable,
+     * fully-trusted target does not need it (no untrusted authorities to gather certificates for).
+     */
+    public static void trustAllAuthoritiesIfOptedIn(IProvisioningAgent agent, IProfile profile) {
+        if (!trustAllAuthoritiesOptedIn()) {
+            return;
+        }
+        var status = new AuthorityChecker(agent, profile).setTrustAlways(true);
+        if (status != null && !status.isOK()) {
+            Logger.warn("Could not persist trustAllAuthorities preference: {}", status.getMessage());
+        }
+        System.out.printf("%s set: trusting all p2 authorities (remote authority verification disabled)%n",
+                TRUST_ALL_AUTHORITIES_ENV);
+    }
+
     public static Path createDirIfNotExist(Path target) {
         if (!target.toFile().exists()) {
             if (!target.toFile().mkdirs()) {
@@ -227,7 +266,6 @@ public class Utils {
             System.out.print("\u001b[2J\u001b[H"); // or "\033[2J\033[H"
             System.out.flush();
         }
-
 
         private void printMostRecentUpdates() {
             for (var update : mostRecentUpdates.values()) {


### PR DESCRIPTION
Replacement for #98 because I could not push to the contributor fork branch.

Changes:
- Rebased the trust-all-authorities opt-in onto the current `knime` branch.
- Preserved `target.trustAllAuthorities` / `PDE_TRUST_ALL_AUTHORITIES` behavior.
- Dropped the unrelated progress monitor rewrite from the original PR diff.
- Added/updated target install argument tests for the new opt-in flag.

Local verification:
- `./gradlew :pde-launch-engine:test --tests 'cn.varsa.pde.resolver.cli.TargetInstallInputsTest' --tests 'cn.varsa.pde.resolver.cli.TargetInstallCopyPathTest' :target-installer:build`

Signed-off-by: opencode/ses_0e1e307e3ffeT0lYFM3OoTut08