### PR TITLE
Make resolver tests OS-agnostic

### DIFF
--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/algo/ResolverTest.kt
@@ -94,7 +94,8 @@ class ResolverTest {
     val result = Resolver.resolve(target, emptyList(), entry)
     val picked = result.bundles.firstOrNull { it.bsn == "b" }
     assertNotNull(picked)
-    assertEquals(listOf(Paths.get("/tmp/b.source-1.0.0")), picked!!.sourceEntries)
+    // sourceEntries are absolutized+normalized by the resolver; mirror that so the assertion is OS-agnostic.
+    assertEquals(listOf(Paths.get("/tmp/b.source-1.0.0").toAbsolutePath().normalize()), picked!!.sourceEntries)
   }
 
   @Test

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
@@ -50,7 +50,8 @@ class CompileServiceTest {
     assertEquals("org.example.test", spec.bsn)
     assertEquals("workspace", spec.origin)
     assertEquals(wsPath.toString(), spec.bundlePath)
-    assertTrue(spec.classpath.contains(wsPath.toString()))
+    // classpath entries are absolutized+normalized by CompileService; mirror that (bundlePath/sourceRoots are raw).
+    assertTrue(spec.classpath.contains(wsPath.toAbsolutePath().normalize().toString()))
     assertTrue(spec.sourceRoots.contains(wsPath.resolve("src").toString()))
     assertEquals(listOf("META-INF/", ".", "icons/"), spec.resourceIncludes)
     assertEquals(listOf("**/*.bak"), spec.resourceExcludes)
@@ -134,7 +135,10 @@ class CompileServiceTest {
 
     val spec = CompileService.buildSpecs(plan, listOf(wsDesc)).specs.first { it.bsn == "org.example.a" }
 
-    assertTrue(spec.classpath.any { it == tpPath.toString() }, "classpath should include target bundle dependency")
+    assertTrue(
+      spec.classpath.contains(tpPath.toAbsolutePath().normalize().toString()),
+      "classpath should include target bundle dependency"
+    )
   }
 
   @Test

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/PlanRewriterTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/PlanRewriterTest.kt
@@ -6,7 +6,6 @@ import org.junit.Test
 import org.osgi.framework.Version
 import java.nio.file.Path
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class PlanRewriterTest {
 
@@ -40,7 +39,9 @@ class PlanRewriterTest {
     val ws = rewritten.bundles.first { it.bsn == "ws.bundle" }
     val tp = rewritten.bundles.first { it.bsn == "tp.bundle" }
 
-    assertTrue(ws.location.toString().endsWith("/ws/ws.bundle/bin"), "workspace bundle should point to compiled output")
-    assertEquals("/tp/tp.bundle", tp.location.toString())
+    // Compare Path objects (not OS-specific strings): the workspace location is the rewritten,
+    // absolutized+normalized output dir; the target bundle is untouched.
+    assertEquals(Path.of("/ws/ws.bundle/bin").toAbsolutePath().normalize(), ws.location)
+    assertEquals(Path.of("/tp/tp.bundle"), tp.location)
   }
 }


### PR DESCRIPTION
Split from original PR #95.

This PR contains only the resolver test path-normalization changes in `ResolverTest.kt`, `CompileServiceTest.kt`, and `PlanRewriterTest.kt`.

Verification:
`./gradlew :pde-resolver:test --tests cn.varsa.pde.resolver.algo.ResolverTest --tests cn.varsa.pde.resolver.compile.CompileServiceTest --tests cn.varsa.pde.resolver.compile.PlanRewriterTest`

Signed-off-by: opencode/ses_0d919dcf2ffe23B6eCey9vvGNy