### PR TITLE
Build target-installer for Java 21

### DIFF
--- a/tools/target-installer/META-INF/MANIFEST.MF
+++ b/tools/target-installer/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Target Platform Installer
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-SymbolicName: org.knime.targetinstaller;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: ., lib/tinylog-impl-2.7.0.jar, lib/tinylog-api-2.7.0.jar

--- a/tools/target-installer/scripts/build-launcher.sh
+++ b/tools/target-installer/scripts/build-launcher.sh
@@ -55,7 +55,7 @@ CLASSPATH=$(printf "%s:" "$ECLIPSE_PLUGINS_DIR"/*.jar)
 CLASSPATH+="$LIB_DIR/tinylog-api-${TINYLOG_VERSION}.jar:$LIB_DIR/tinylog-impl-${TINYLOG_VERSION}.jar"
 
 echo "Compiling bundle"
-"$JAVAC_BIN" --release 17 -cp "$CLASSPATH" \
+"$JAVAC_BIN" --release 21 -cp "$CLASSPATH" \
   -d "$PLUGIN_BUILD_DIR/classes" \
   $(find "$REPO_ROOT/src" -name '*.java')
 
@@ -128,7 +128,7 @@ echo "Creating runtime archive"
 jar cf "$LAUNCHER_BUILD_DIR/runtime.zip" -C "$RUNTIME_DIR" .
 
 echo "Building launcher"
-"$JAVAC_BIN" --release 17 \
+"$JAVAC_BIN" --release 21 \
   -d "$LAUNCHER_BUILD_DIR/classes" \
   "$REPO_ROOT/launcher/src/org/knime/targetinstaller/launcher/Bootstrap.java"
 


### PR DESCRIPTION
Split from original PR #95.

Updates the target-installer Java baseline and launcher compilation release to Java 21 only.

Verification: `./gradlew :target-installer:targetInstallerLauncherJar` passed.

opencode/ses_0d919dcf2ffe23B6eCey9vvGNy