### PR TITLE
Use a javac argfile for target-installer compilation

### DIFF
--- a/tools/target-installer/scripts/build-launcher.sh
+++ b/tools/target-installer/scripts/build-launcher.sh
@@ -63,9 +63,19 @@ CLASSPATH=$(printf "%s:" "$ECLIPSE_PLUGINS_DIR"/*.jar)
 CLASSPATH+="$LIB_DIR/tinylog-api-${TINYLOG_VERSION}.jar:$LIB_DIR/tinylog-impl-${TINYLOG_VERSION}.jar"
 
 echo "Compiling bundle"
-"$JAVAC_BIN" --release 21 -cp "$CLASSPATH" \
-  -d "$PLUGIN_BUILD_DIR/classes" \
-  $(find "$REPO_ROOT/src" -name '*.java')
+# Pass options/sources via an @argfile: the full classpath plus source list can
+# exceed the OS command-line length limit.
+JAVAC_ARGS="$BUILD_DIR/javac-bundle-args.txt"
+{
+  echo "--release"
+  echo "21"
+  echo "-cp"
+  printf '"%s"\n' "$CLASSPATH"
+  echo "-d"
+  printf '"%s"\n' "$PLUGIN_BUILD_DIR/classes"
+  find "$REPO_ROOT/src" -name '*.java' | while IFS= read -r f; do printf '"%s"\n' "$f"; done
+} > "$JAVAC_ARGS"
+"$JAVAC_BIN" "@$JAVAC_ARGS"
 
 echo "Packaging bundle"
 jar cfm "$PLUGIN_DIR/$PLUGIN_JAR" \


### PR DESCRIPTION
Split out from #95.

This PR changes the target-installer bundle compilation to pass javac options and source files through an `@argfile`, avoiding command-line length limits while preserving the existing Java release level.

Verification:
- `bash -n tools/target-installer/scripts/build-launcher.sh`
- `./gradlew :target-installer:targetInstallerLauncherJar`

opencode/ses_0d919dcf2ffe23B6eCey9vvGNy