### PR TITLE
fix(compile): warn instead of failing when annotation processors are on the classpath

### DIFF
--- a/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
+++ b/core/pde-launch-engine/src/main/kotlin/cn/varsa/pde/resolver/cli/Main.kt
@@ -4513,10 +4513,9 @@ fun compileMain(args: Array<String>): Int {
       if (spec?.isWorkspace == true && result.success && !result.skipped) {
         logger.info("built ${result.bsn} in ${formatDuration(result.durationMillis)}")
       }
-      val classfileWarning = extractClassfileWarning(result.output)
-      if (classfileWarning != null) {
+      if (result.warnings.isNotEmpty()) {
         logger.warning("${result.bsn}:")
-        logger.warning(classfileWarning)
+        result.warnings.forEach { logger.warning(it) }
       }
     }
     val allOk = results.all { it.success }
@@ -4599,13 +4598,8 @@ private fun formatDuration(durationMillis: Long): String {
 private fun extractErrorBlocks(output: String): String? {
   val trimmed = output.trim()
   if (trimmed.isEmpty()) return null
-  if (!trimmed.contains("ERROR in")) {
-    val knownFailures = listOf(
-      "Classpath contains class files requiring a newer Java version",
-      "Annotation processors detected; javac fallback not implemented"
-    )
-    return if (knownFailures.any { trimmed.contains(it) }) trimmed else null
-  }
+  // No structured ECJ problem blocks: surface whatever the compiler said verbatim.
+  if (!trimmed.contains("ERROR in")) return trimmed
   val lines = output.lineSequence().toList()
   val blocks = mutableListOf<String>()
   var i = 0
@@ -4628,30 +4622,6 @@ private fun extractErrorBlocks(output: String): String? {
     blocks += sb.toString().trimEnd()
   }
   return blocks.joinToString("\n")
-}
-
-private fun extractClassfileWarning(output: String): String? {
-  val marker = "WARNING: Classpath contains class files requiring a newer Java version"
-  val lines = output.lineSequence().toList()
-  val startIndex = lines.indexOfFirst { it.startsWith(marker) }
-  if (startIndex < 0) return null
-  val warningLines = mutableListOf<String>()
-  for (i in startIndex until lines.size) {
-    val line = lines[i]
-    if (i != startIndex && line.isBlank()) break
-    if (
-      i != startIndex &&
-      !line.startsWith("Target: ") &&
-      !line.startsWith("- ") &&
-      !line.startsWith("... and ") &&
-      !line.startsWith("Use a target platform ") &&
-      !line.startsWith("WARNING:")
-    ) {
-      break
-    }
-    warningLines += line
-  }
-  return warningLines.joinToString("\n").trimEnd().ifEmpty { null }
 }
 
 fun main(args: Array<String>) {

--- a/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/CompileMainProcessorWarningTest.kt
+++ b/core/pde-launch-engine/src/test/kotlin/cn/varsa/pde/resolver/cli/CompileMainProcessorWarningTest.kt
@@ -1,0 +1,91 @@
+package cn.varsa.pde.resolver.cli
+
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.outputStream
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end shape of the KNIME report: one bundle ships a processor-declaring jar on its own
+ * Bundle-ClassPath, another unrelated bundle in the same plan does not. `pde compile` must build
+ * both and warn only about the bundle that actually carries the processor.
+ */
+class CompileMainProcessorWarningTest {
+
+  @Test
+  fun `warns only for the bundle whose own classpath declares processors`() {
+    val baseDir = Files.createTempDirectory("cfg")
+    val workspace = Files.createTempDirectory("ws")
+    createProfileWithFramework(baseDir)
+
+    val provider = workspace.resolve("org.example.provider")
+    createBundle(provider, "org.example.provider", bundleClassPath = ".,libs/auto-value-1.11.0.jar")
+    processorJar(provider.resolve("libs").createDirectories().resolve("auto-value-1.11.0.jar"))
+
+    val consumer = workspace.resolve("org.example.consumer")
+    createBundle(consumer, "org.example.consumer", bundleClassPath = ".")
+
+    val configFile = baseDir.resolve("pde.yaml")
+    configFile.writeText(
+      """
+        target:
+          profileId: profile
+          p2Path: target/p2
+        bundles:
+          - path: ${provider.toAbsolutePath()}
+          - path: ${consumer.toAbsolutePath()}
+      """.trimIndent()
+    )
+
+    val stderr = ByteArrayOutputStream()
+    val originalErr = System.err
+    val exitCode = try {
+      System.setErr(PrintStream(stderr, true))
+      compileMain(arrayOf("--config", configFile.toString()))
+    } finally {
+      System.setErr(originalErr)
+    }
+    val logged = stderr.toString()
+
+    assertEquals(0, exitCode, "Both bundles should compile:\n$logged")
+    assertTrue(
+      provider.resolve("bin/Dummy.class").toFile().exists() &&
+        consumer.resolve("bin/Dummy.class").toFile().exists(),
+      "Both bundles should have emitted class files:\n$logged"
+    )
+    assertTrue(logged.contains("org.example.provider:"), "Provider should be warned about:\n$logged")
+    assertTrue(logged.contains("-proc:none"), "Warning text should reach stderr:\n$logged")
+    assertTrue(logged.contains("auto-value-1.11.0.jar"), "Warning should name the jar:\n$logged")
+    assertFalse(logged.contains("org.example.consumer:"), "Consumer must not be warned about:\n$logged")
+  }
+
+  private fun createBundle(dir: Path, bsn: String, bundleClassPath: String) {
+    dir.resolve("META-INF").createDirectories().resolve("MANIFEST.MF").writeText(
+      """
+        Manifest-Version: 1.0
+        Bundle-ManifestVersion: 2
+        Bundle-SymbolicName: $bsn
+        Bundle-Version: 1.0.0
+        Bundle-ClassPath: $bundleClassPath
+      """.trimIndent() + "\n"
+    )
+    dir.resolve("src").createDirectories().resolve("Dummy.java").writeText("class Dummy {}")
+  }
+
+  private fun processorJar(target: Path) {
+    JarOutputStream(target.outputStream()).use { jar ->
+      jar.putNextEntry(JarEntry("META-INF/services/javax.annotation.processing.Processor"))
+      jar.write("com.example.Processor".toByteArray())
+      jar.closeEntry()
+    }
+  }
+}

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileExecutor.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileExecutor.kt
@@ -14,7 +14,9 @@ data class BundleCompileResult(
   val success: Boolean,
   val output: String,
   val durationMillis: Long,
-  val skipped: Boolean
+  val skipped: Boolean,
+  /** Advisory diagnostics that do not fail the bundle; reported alongside the result. */
+  val warnings: List<String> = emptyList()
 )
 
 object CompileExecutor {

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileService.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileService.kt
@@ -71,9 +71,10 @@ object CompileService {
     allClassPathEntries: List<String>
   ): CompileSpec {
     val w = if (rb.isWorkspace) byPath[rb.path.toAbsolutePath().normalize()] else null
+    val ownClasspath = rb.classPathEntries.map { it.toAbsolutePath().normalize().toString() }
     val effectiveClasspath = linkedSetOf<String>().apply {
       // Prefer bundle-specific classPathEntries first (bin includes, Bundle-ClassPath)
-      addAll(rb.classPathEntries.map { it.toAbsolutePath().normalize().toString() })
+      addAll(ownClasspath)
       // Then add all resolved bundle locations (workspace + TP) for dependencies
       addAll(allClassPathEntries)
     }.toList()
@@ -83,6 +84,7 @@ object CompileService {
       origin = if (rb.isWorkspace) "workspace" else "target",
       bundlePath = rb.path.toString(),
       classpath = effectiveClasspath,
+      ownClasspath = ownClasspath,
       sourceRoots = w?.sourceRoots?.map { it.toString() } ?: emptyList(),
       resourceIncludes = w?.resourceIncludes ?: emptyList(),
       resourceExcludes = w?.resourceExcludes ?: emptyList(),

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileSpec.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/CompileSpec.kt
@@ -9,7 +9,10 @@ data class CompileSpec(
   val version: String,
   val origin: String,
   val bundlePath: String,
+  /** Full compile classpath handed to the compiler: own entries plus resolved dependencies. */
   val classpath: List<String>,
+  /** Only this bundle's own classpath entries (bin includes, Bundle-ClassPath, extra jars). */
+  val ownClasspath: List<String> = emptyList(),
   val sourceRoots: List<String>,
   val resourceIncludes: List<String>,
   val resourceExcludes: List<String>,
@@ -33,6 +36,7 @@ object CompileSpecBuilder {
       origin = if (rb.isWorkspace) "workspace" else "target",
       bundlePath = rb.path.toString(),
       classpath = rb.classPathEntries.map { it.toString() },
+      ownClasspath = rb.classPathEntries.map { it.toString() },
       sourceRoots = w?.sourceRoots?.map { it.toString() } ?: emptyList(),
       resourceIncludes = w?.resourceIncludes ?: emptyList(),
       resourceExcludes = w?.resourceExcludes ?: emptyList(),

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/EcjCompiler.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/EcjCompiler.kt
@@ -11,11 +11,7 @@ import java.util.logging.Logger
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
-class EcjCompiler(
-  // Processors are never executed (see -proc:none below), so their presence on the
-  // classpath is reported as a warning rather than failing the bundle.
-  private val failOnProcessors: Boolean = false
-) : CompilerPort {
+class EcjCompiler : CompilerPort {
 
   private val logger = Logger.getLogger(EcjCompiler::class.java.name)
 
@@ -48,28 +44,18 @@ class EcjCompiler(
       )
     }
 
-    val processorReasons = detectAnnotationProcessors(bundleRoot, spec.classpath)
-    val processorWarning = if (processorReasons.isEmpty() || failOnProcessors) {
+    // Processors are never executed (see -proc:none below), so their presence is reported
+    // as a warning: the bundle only breaks if it needs the sources they would generate, and
+    // then it fails on its own with an unresolved-type error naming the generated type.
+    val processorReasons = detectAnnotationProcessors(bundleRoot, spec.ownClasspath)
+    val processorWarning = if (processorReasons.isEmpty()) {
       null
     } else {
       buildString {
-        append("WARNING: Annotation processors on the classpath are not run (-proc:none).\n")
+        append("WARNING: Annotation processors on this bundle's own classpath are not run (-proc:none).\n")
         processorReasons.forEach { append("- ").append(it).append('\n') }
         append("Compilation only fails if this bundle needs the sources they would generate.")
       }
-    }
-    if (failOnProcessors && processorReasons.isNotEmpty()) {
-      val msg = buildString {
-        append("Annotation processors detected; javac fallback not implemented.\n")
-        processorReasons.forEach { append("- ").append(it).append('\n') }
-      }
-      return BundleCompileResult(
-        spec.bsn,
-        success = false,
-        output = msg.trimEnd(),
-        durationMillis = 0,
-        skipped = false
-      )
     }
 
     val args = mutableListOf<String>()
@@ -123,24 +109,13 @@ class EcjCompiler(
     val compiler = Main(writer, writer, false, null, null)
     val success = compiler.compile(args.toTypedArray())
 
-    val output = buildString {
-      processorWarning?.let {
-        append(it.trimEnd())
-        append("\n")
-      }
-      classfileWarning?.let {
-        append(it.trimEnd())
-        append("\n")
-      }
-      append(baos.toString())
-    }
-
     return BundleCompileResult(
       spec.bsn,
       success = success,
-      output = output,
+      output = baos.toString(),
       durationMillis = 0,
-      skipped = false
+      skipped = false,
+      warnings = listOfNotNull(processorWarning, classfileWarning).map { it.trimEnd() }
     )
   }
 
@@ -168,12 +143,18 @@ class EcjCompiler(
     return "-g:" + parts.joinToString(",")
   }
 
-  private fun detectAnnotationProcessors(bundleRoot: Path, classpath: List<String>): List<String> {
+  /**
+   * Detects annotation processing configured *for this bundle*: a JDT APT factorypath in the
+   * bundle root, or a processor-declaring jar on the bundle's own classpath (its output dir and
+   * Bundle-ClassPath entries). Deliberately not the full resolved classpath: a processor jar
+   * shipped inside some unrelated required bundle says nothing about this bundle.
+   */
+  private fun detectAnnotationProcessors(bundleRoot: Path, ownClasspath: List<String>): List<String> {
     val reasons = mutableListOf<String>()
     if (Files.exists(bundleRoot.resolve(".factorypath")) || Files.exists(bundleRoot.resolve("factorypath.xml"))) {
       reasons += "factorypath file present in bundle root"
     }
-    classpath.forEach { entry ->
+    ownClasspath.forEach { entry ->
       val path = Path.of(entry)
       val name = path.fileName?.toString()?.lowercase() ?: ""
       if (name.contains("lombok")) {

--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/EcjCompiler.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/compile/EcjCompiler.kt
@@ -12,7 +12,9 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
 class EcjCompiler(
-  private val failOnProcessors: Boolean = true
+  // Processors are never executed (see -proc:none below), so their presence on the
+  // classpath is reported as a warning rather than failing the bundle.
+  private val failOnProcessors: Boolean = false
 ) : CompilerPort {
 
   private val logger = Logger.getLogger(EcjCompiler::class.java.name)
@@ -47,6 +49,15 @@ class EcjCompiler(
     }
 
     val processorReasons = detectAnnotationProcessors(bundleRoot, spec.classpath)
+    val processorWarning = if (processorReasons.isEmpty() || failOnProcessors) {
+      null
+    } else {
+      buildString {
+        append("WARNING: Annotation processors on the classpath are not run (-proc:none).\n")
+        processorReasons.forEach { append("- ").append(it).append('\n') }
+        append("Compilation only fails if this bundle needs the sources they would generate.")
+      }
+    }
     if (failOnProcessors && processorReasons.isNotEmpty()) {
       val msg = buildString {
         append("Annotation processors detected; javac fallback not implemented.\n")
@@ -113,6 +124,10 @@ class EcjCompiler(
     val success = compiler.compile(args.toTypedArray())
 
     val output = buildString {
+      processorWarning?.let {
+        append(it.trimEnd())
+        append("\n")
+      }
       classfileWarning?.let {
         append(it.trimEnd())
         append("\n")

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/CompileServiceTest.kt
@@ -142,6 +142,45 @@ class CompileServiceTest {
   }
 
   @Test
+  fun `own classpath excludes resolved dependencies`() {
+    val wsPath = Paths.get("/workspace/org.example.a")
+    val tpPath = Paths.get("/target/org.foo")
+    val wsDesc = WorkspaceBundleDescriptor(
+      path = wsPath,
+      manifest = dummyManifest("org.example.a", "1.0.0"),
+      classPathEntries = listOf(wsPath)
+    )
+    val selected = listOf(
+      ResolvedBundle(
+        bsn = "org.example.a",
+        version = Version.parseVersion("1.0.0"),
+        path = wsPath,
+        origin = cn.varsa.pde.resolver.algo.BundleOrigin.WORKSPACE,
+        classPathEntries = listOf(wsPath),
+        sourceEntries = emptyList()
+      ),
+      ResolvedBundle(
+        bsn = "org.foo",
+        version = Version.parseVersion("2.0.0"),
+        path = tpPath,
+        origin = cn.varsa.pde.resolver.algo.BundleOrigin.TARGET,
+        classPathEntries = listOf(tpPath),
+        sourceEntries = emptyList()
+      )
+    )
+    val plan = LaunchPlanner.PlanResult(
+      plan = LauncherPlan(emptyList(), null, emptyMap()),
+      context = LaunchContext(emptyMap(), emptyMap()),
+      selectedBundles = selected,
+      workspaceDependencies = emptyMap()
+    )
+
+    val spec = CompileService.buildSpecs(plan, listOf(wsDesc)).specs.first { it.bsn == "org.example.a" }
+
+    assertEquals(listOf(wsPath.toAbsolutePath().normalize().toString()), spec.ownClasspath)
+  }
+
+  @Test
   fun `workspace specs are ordered by dependencies`() {
     val aPath = Paths.get("/workspace/a")
     val bPath = Paths.get("/workspace/b")

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/EcjCompilerTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/EcjCompilerTest.kt
@@ -4,9 +4,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class EcjCompilerTest {
@@ -49,73 +49,101 @@ class EcjCompilerTest {
   }
 
   @Test
-  fun `warns but compiles when annotation processors present`() {
+  fun `warns but compiles when the bundle declares annotation processors`() {
     val bundle = temp.newFolder("bundle2").toPath()
     val srcDir = bundle.resolve("src").also { it.toFile().mkdirs() }
     srcDir.resolve("Dummy.java").toFile().writeText("class Dummy {}")
 
-    // Create a fake processor jar with service entry
-    val procJar = temp.newFile("processor.jar")
-    JarOutputStream(procJar.outputStream()).use { jar ->
-      jar.putNextEntry(JarEntry("META-INF/services/javax.annotation.processing.Processor"))
-      jar.write("com.example.Processor".toByteArray())
-      jar.closeEntry()
-    }
+    val procJar = processorJar("processor.jar")
 
-    val spec = CompileSpec(
+    val spec = specFor(
       bsn = "demo.processor",
-      version = "1.0.0",
-      origin = "workspace",
-      bundlePath = bundle.toString(),
+      bundle = bundle,
+      srcDir = srcDir,
       classpath = listOf(procJar.absolutePath),
-      sourceRoots = listOf(srcDir.toString()),
-      resourceIncludes = emptyList(),
-      resourceExcludes = emptyList(),
-      compilerPrefs = emptyMap(),
-      executionEnvironment = null,
-      outputDirectory = bundle.resolve("bin").toString(),
-      isWorkspace = true
+      ownClasspath = listOf(procJar.absolutePath)
     )
 
     val result = EcjCompiler().compile(spec)
 
     assertTrue(result.success, "Processors on the classpath must not fail an otherwise valid bundle")
-    assertTrue(result.output.contains("Annotation processors"), "Output should mention processors")
-    assertTrue(result.output.contains("-proc:none"), "Warning should say the processors are not run")
+    val warning = result.warnings.single()
+    assertTrue(warning.contains("Annotation processors"), "Warning should mention processors")
+    assertTrue(warning.contains("-proc:none"), "Warning should say the processors are not run")
+    assertTrue(warning.contains(procJar.absolutePath), "Warning should name the offending jar")
     assertTrue(bundle.resolve("bin/Dummy.class").toFile().exists(), "Class file should be emitted")
   }
 
   @Test
-  fun `fails fast when annotation processors present and configured to do so`() {
+  fun `does not warn when a processor jar comes only from a dependency`() {
     val bundle = temp.newFolder("bundle3").toPath()
     val srcDir = bundle.resolve("src").also { it.toFile().mkdirs() }
     srcDir.resolve("Dummy.java").toFile().writeText("class Dummy {}")
 
-    val procJar = temp.newFile("processor-strict.jar")
-    JarOutputStream(procJar.outputStream()).use { jar ->
+    // Mirrors the KNIME case: auto-value ships inside a required bundle's libs/, so it lands on
+    // the resolved compile classpath of every bundle in the plan without any of them using APT.
+    val procJar = processorJar("auto-value-1.11.0.jar")
+    val ownBin = bundle.resolve("bin").also { it.toFile().mkdirs() }
+
+    val spec = specFor(
+      bsn = "org.knime.email",
+      bundle = bundle,
+      srcDir = srcDir,
+      classpath = listOf(ownBin.toString(), procJar.absolutePath),
+      ownClasspath = listOf(ownBin.toString())
+    )
+
+    val result = EcjCompiler().compile(spec)
+
+    assertTrue(result.success, "A dependency's processor jar must not fail the bundle")
+    assertTrue(result.warnings.isEmpty(), "A dependency's processor jar must not warn: ${result.warnings}")
+    assertTrue(bundle.resolve("bin/Dummy.class").toFile().exists(), "Class file should be emitted")
+  }
+
+  @Test
+  fun `warns when a factorypath configures annotation processing`() {
+    val bundle = temp.newFolder("bundle4").toPath()
+    val srcDir = bundle.resolve("src").also { it.toFile().mkdirs() }
+    srcDir.resolve("Dummy.java").toFile().writeText("class Dummy {}")
+    bundle.resolve(".factorypath").toFile().writeText("<factorypath/>")
+
+    val result = EcjCompiler().compile(
+      specFor(bsn = "demo.apt", bundle = bundle, srcDir = srcDir, classpath = emptyList(), ownClasspath = emptyList())
+    )
+
+    assertTrue(result.success, "APT configuration must not fail the bundle")
+    assertTrue(result.warnings.single().contains("factorypath"), "Warning should name the factorypath")
+  }
+
+  private fun processorJar(name: String): File {
+    val jarFile = temp.newFile(name)
+    JarOutputStream(jarFile.outputStream()).use { jar ->
       jar.putNextEntry(JarEntry("META-INF/services/javax.annotation.processing.Processor"))
       jar.write("com.example.Processor".toByteArray())
       jar.closeEntry()
     }
-
-    val spec = CompileSpec(
-      bsn = "demo.processor.strict",
-      version = "1.0.0",
-      origin = "workspace",
-      bundlePath = bundle.toString(),
-      classpath = listOf(procJar.absolutePath),
-      sourceRoots = listOf(srcDir.toString()),
-      resourceIncludes = emptyList(),
-      resourceExcludes = emptyList(),
-      compilerPrefs = emptyMap(),
-      executionEnvironment = null,
-      outputDirectory = bundle.resolve("bin").toString(),
-      isWorkspace = true
-    )
-
-    val result = EcjCompiler(failOnProcessors = true).compile(spec)
-
-    assertFalse(result.success, "Compile should fail fast when explicitly configured to")
-    assertTrue(result.output.contains("Annotation processors"), "Output should mention processors")
+    return jarFile
   }
+
+  private fun specFor(
+    bsn: String,
+    bundle: Path,
+    srcDir: Path,
+    classpath: List<String>,
+    ownClasspath: List<String>
+  ) = CompileSpec(
+    bsn = bsn,
+    version = "1.0.0",
+    origin = "workspace",
+    bundlePath = bundle.toString(),
+    classpath = classpath,
+    ownClasspath = ownClasspath,
+    sourceRoots = listOf(srcDir.toString()),
+    resourceIncludes = emptyList(),
+    resourceExcludes = emptyList(),
+    compilerPrefs = emptyMap(),
+    executionEnvironment = null,
+    outputDirectory = bundle.resolve("bin").toString(),
+    isWorkspace = true
+  )
 }

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/EcjCompilerTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/compile/EcjCompilerTest.kt
@@ -49,7 +49,7 @@ class EcjCompilerTest {
   }
 
   @Test
-  fun `fails fast when annotation processors present`() {
+  fun `warns but compiles when annotation processors present`() {
     val bundle = temp.newFolder("bundle2").toPath()
     val srcDir = bundle.resolve("src").also { it.toFile().mkdirs() }
     srcDir.resolve("Dummy.java").toFile().writeText("class Dummy {}")
@@ -79,7 +79,43 @@ class EcjCompilerTest {
 
     val result = EcjCompiler().compile(spec)
 
-    assertFalse(result.success, "Compile should fail fast when processors are detected")
+    assertTrue(result.success, "Processors on the classpath must not fail an otherwise valid bundle")
+    assertTrue(result.output.contains("Annotation processors"), "Output should mention processors")
+    assertTrue(result.output.contains("-proc:none"), "Warning should say the processors are not run")
+    assertTrue(bundle.resolve("bin/Dummy.class").toFile().exists(), "Class file should be emitted")
+  }
+
+  @Test
+  fun `fails fast when annotation processors present and configured to do so`() {
+    val bundle = temp.newFolder("bundle3").toPath()
+    val srcDir = bundle.resolve("src").also { it.toFile().mkdirs() }
+    srcDir.resolve("Dummy.java").toFile().writeText("class Dummy {}")
+
+    val procJar = temp.newFile("processor-strict.jar")
+    JarOutputStream(procJar.outputStream()).use { jar ->
+      jar.putNextEntry(JarEntry("META-INF/services/javax.annotation.processing.Processor"))
+      jar.write("com.example.Processor".toByteArray())
+      jar.closeEntry()
+    }
+
+    val spec = CompileSpec(
+      bsn = "demo.processor.strict",
+      version = "1.0.0",
+      origin = "workspace",
+      bundlePath = bundle.toString(),
+      classpath = listOf(procJar.absolutePath),
+      sourceRoots = listOf(srcDir.toString()),
+      resourceIncludes = emptyList(),
+      resourceExcludes = emptyList(),
+      compilerPrefs = emptyMap(),
+      executionEnvironment = null,
+      outputDirectory = bundle.resolve("bin").toString(),
+      isWorkspace = true
+    )
+
+    val result = EcjCompiler(failOnProcessors = true).compile(spec)
+
+    assertFalse(result.success, "Compile should fail fast when explicitly configured to")
     assertTrue(result.output.contains("Annotation processors"), "Output should mention processors")
   }
 }


### PR DESCRIPTION
## What was wrong

`pde compile` refused to build several bundles in a KNIME workspace with

```
ERROR: Annotation processors detected on the classpath, but pde does not run them.
- auto-value-1.11.0.jar declares META-INF/services/javax.annotation.processing.Processor
Compile this bundle with Tycho/Eclipse instead.
```

Three things combine into that failure:

1. **The detection is jar-based, not usage-based.** `detectAnnotationProcessors()` scans every
   classpath entry for `META-INF/services/javax.annotation.processing.Processor` and reports a hit.
   In the KNIME case the jar is `auto-value-1.11.0.jar`, shipped inside
   `org.knime.ext.google.sdk_*/libs/`. It arrives transitively — the bundles that failed
   (`org.knime.email`, `org.knime.google.api`, …) don't use AutoValue at all; they just require the
   Google SDK bundle for its API.

2. **The guard was unconditional.** `failOnProcessors` had no override — it was effectively a
   hardcoded `true` — so any bundle whose resolved classpath happened to contain such a jar became
   uncompilable, and there was no way to say "compile it anyway".

3. **The guard protected against something that cannot happen.** The very next lines of
   `buildArgs()` already pass `-proc:none`, so ECJ never runs a processor. A bundle only actually
   breaks if it *needs* the sources a processor would have generated — and then it fails on its own,
   with a normal "cannot be resolved" error pointing at the generated type. Refusing up front turned
   a hypothetical problem into a guaranteed one.

Tycho builds the same bundles fine because it has no equivalent check.

## What this changes

Processor detection no longer fails a bundle, and the warning that replaces it is scoped and
actually reaches the user.

- **Warning is the only behaviour.** `failOnProcessors` is gone, along with the strict branch. It
  was unreachable anyway: no flag, no config key, one defaulted call site.
- **Warnings are structured, not string-prefixed.** `BundleCompileResult` carries a `warnings` list;
  `EcjCompiler` returns the processor warning and the existing classfile-version warning in it, and
  `compileMain` logs them per bundle on the `[WARN]` channel. This is the part that makes the
  warning visible at all: prepending it to `output` did nothing, because `pde compile` only ever
  extracted the classfile warning from there, matching the first line starting with that warning's
  own marker. `extractClassfileWarning` and its prefix parsing are deleted, as is the
  `knownFailures` allowlist in `extractErrorBlocks` — both entries were dead once warnings stopped
  travelling through `output`.
- **Detection is scoped per bundle.** `CompileSpec` also carries `ownClasspath` — the bundle's own
  entries (output dir + `Bundle-ClassPath`), which `CompileService` already computed as the head of
  `effectiveClasspath` and then discarded — and detection reads that instead of the whole
  resolution. A processor jar shipped inside an unrelated required bundle no longer says anything
  about this bundle. The ECJ classpath is unchanged: narrowing that needs a real per-bundle
  `Require-Bundle`/`Import-Package` closure (with re-export, fragment and split-package handling),
  and `PlanResult` exposes no dependency graph for non-workspace bundles.

## Tests

`EcjCompilerTest`: warns and compiles when the bundle's own classpath declares processors (asserting
on `warnings`, and that the jar is named); **no** warning when the processor jar arrives only via the
union classpath (the KNIME shape); warns on a `.factorypath`.

`CompileServiceTest`: `own classpath excludes resolved dependencies`.

`CompileMainProcessorWarningTest` (new) drives `compileMain` end to end over a two-bundle workspace
where one bundle ships a processor jar on its `Bundle-ClassPath`: exit 0, both bundles emit class
files, the warning reaches stderr for that bundle and nothing for the other. The pre-change code
printed nothing at all here.

`./gradlew build` is green.

## Verified against the reported workspace

Same `pde compile` over all four `knime-email` bundles, CLI built from three revisions:

| build | exit | processor output |
|---|---|---|
| base `knime` | 1 | `Annotation processors detected; javac fallback not implemented.` × 3 bundles |
| this PR, first commit | 0 | nothing — no mention of processors anywhere in the log |
| this PR, final | 0 | nothing, correctly — no jar in that workspace declares a processor |

The only processor-declaring jar is `auto-value-1.11.0.jar` inside the target-platform bundle
`org.knime.ext.google.sdk_5.13.0`, so attributing it to `org.knime.email` was always wrong. Positive
control: copying that jar into a workspace copy of `org.knime.email` and adding it to
`Bundle-ClassPath` produces the warning, and the bundle still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
