### PR TITLE
fix(launch): accept workspace bundles without Java sources

### DIFF
--- a/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/workspace/WorkspaceModuleBuilder.kt
+++ b/core/pde-resolver/src/main/kotlin/cn/varsa/pde/resolver/workspace/WorkspaceModuleBuilder.kt
@@ -43,7 +43,9 @@ object WorkspaceModuleBuilder {
 
       val effectiveClassPath = when {
         devClassPaths.isNotEmpty() -> {
-          if (!allowMissingClasses && moduleDir.toFile().isDirectory && !containsClasses(devClassPaths)) {
+          // Bundles without Java sources (e.g. pure resource/JS bundles) legitimately have no .class files.
+          val hasSources = descriptor.sourceRoots.isNotEmpty()
+          if (!allowMissingClasses && hasSources && moduleDir.toFile().isDirectory && !containsClasses(devClassPaths)) {
             val requested = classRoots.joinToString(", ") { moduleDir.resolve(it).toString() }
             throw WorkspaceModuleException(
               "No compiled classes found for workspace bundle $bsn. Checked: $requested"

--- a/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/workspace/WorkspaceModuleBuilderTest.kt
+++ b/core/pde-resolver/src/test/kotlin/cn/varsa/pde/resolver/workspace/WorkspaceModuleBuilderTest.kt
@@ -64,11 +64,32 @@ class WorkspaceModuleBuilderTest {
         "Bundle-SymbolicName: test.module\n" +
         "Bundle-Version: 1.0.0\n\n"
     )
+    File(moduleDir.toFile(), "src").mkdirs()
     val outDir = File(moduleDir.toFile(), "bin")
     outDir.mkdirs()
 
-    // Output directory exists but contains no .class files; should fail fast
+    // Sources exist but output directory contains no .class files; should fail fast
     WorkspaceModuleBuilder.build(listOf(WorkspaceModuleDefinition(moduleDir)))
+  }
+
+  @Test
+  fun `accepts bundle without java sources and without class files`() {
+    val moduleDir = temp.newFolder("module-resources-only").toPath()
+    val metaInf = File(moduleDir.toFile(), "META-INF")
+    metaInf.mkdirs()
+    File(metaInf, "MANIFEST.MF").writeText(
+      "Bundle-ManifestVersion: 2\n" +
+        "Bundle-SymbolicName: test.module.resources\n" +
+        "Bundle-Version: 1.0.0\n\n"
+    )
+    // No source.. entry and no src/ folder: nothing to compile, so an empty bin/ is fine.
+    File(moduleDir.toFile(), "build.properties").writeText("bin.includes = META-INF/,dist/\n")
+    File(moduleDir.toFile(), "bin").mkdirs()
+
+    val inputs = WorkspaceModuleBuilder.build(listOf(WorkspaceModuleDefinition(moduleDir)))
+
+    assertEquals(1, inputs.descriptors.size)
+    assertEquals(listOf("bin"), inputs.devProperties["test.module.resources"])
   }
 
   @Test


### PR DESCRIPTION
Bundles that carry only resources (e.g. org.knime.ui.js, whose
build.properties has no `source.` entries and no src/ folder) have no
.class files, so `pde launch` failed with "No compiled classes found".
Skip the class-file check when the bundle declares no source roots;
bundles with sources but an empty output directory still fail fast.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
